### PR TITLE
fix: get_project_services filter & numeric param coercion

### DIFF
--- a/.claude/skills/productive/SKILL.md
+++ b/.claude/skills/productive/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: productive
+description: Interact with Productive.io — log time, manage tasks, view projects, track activities, and more. Use when the user mentions Productive.io, timesheets, logging hours, recording time, task management in Productive, or any project management operations that should go through Productive.io.
+argument-hint: [action and details]
+---
+
+# Productive.io Skill
+
+Interact with Productive.io for project management, time tracking, task management, and more via the `productive` MCP server.
+
+## Available Capabilities
+
+### Time Tracking
+- `list_time_entries` — view logged time (filter by date, person, project, task, service)
+- `create_time_entry` — log new time entries
+- `update_time_entry` — update an existing time entry (date, time, note, billable_time). Only works on unsubmitted/unapproved entries.
+- `delete_time_entry` — delete an existing time entry. Only works on unsubmitted/unapproved entries.
+- `get_project_services` — get services available for a project (needed to create time entries)
+- `list_project_deals` — list deals/budgets for a project
+- `list_deal_services` — list services for a deal/budget
+- `list_services` — list all services in the org
+
+### Task Management
+- `list_tasks` / `get_task` / `get_project_tasks` / `my_tasks` — view tasks
+- `create_task` — create new tasks
+- `update_task_status` — change task status (requires workflow_status_id from `list_workflow_statuses`)
+- `update_task_assignment` — reassign tasks
+- `update_task_details` — edit task details
+- `add_task_comment` — comment on tasks
+- `update_task_sprint` — assign tasks to sprints
+- `move_task_to_list` / `add_to_backlog` / `reposition_task` — organize tasks
+
+### Projects & Organization
+- `list_projects` / `list_companies` — browse projects and companies
+- `list_boards` / `create_board` — manage project boards
+- `list_task_lists` / `create_task_list` — manage task lists within boards
+- `list_workflow_statuses` — see available status options
+
+### Activity & Context
+- `list_activities` / `get_recent_updates` — view recent changes across the org
+- `whoami` — check current user context
+
+## Time Entry Workflow (MUST FOLLOW)
+
+When logging time, follow these steps in order:
+
+### 1. Identify the correct project
+- Map what the user describes to a Productive.io project. Use `list_projects` if needed.
+- If unclear which project the work belongs to, **ask explicitly** — do not guess.
+- The user may reference work that gets logged under a different project than expected. Use conversation context to determine this, but ask if ambiguous.
+
+### 2. Get the project's services
+- Use `get_project_services` with the project ID to get services belonging to that project's budget.
+
+### 3. Handle budget errors automatically
+- If `create_time_entry` fails with "outside budget date range", try other services for that project automatically — don't ask the user to look it up.
+
+### 4. Draft the note and confirm
+- Before creating, show the user a summary table of each entry (date, time, project, service, note).
+- Ask if they want to add additional detail to the note — e.g. specific tasks accomplished, context about why the work was done, or references to conversations. Don't use generic notes.
+- Once confirmed, create the entry.
+
+### 5. Create the entry
+- Use `create_time_entry` with `person_id: "me"` (requires PRODUCTIVE_USER_ID to be configured).
+- If creating multiple entries across different projects, verify the project/service mapping for each one individually.
+
+## Known Gotchas
+- Service IDs change when budgets roll over. Always query fresh rather than reusing cached IDs.
+- Some API tokens may not have permission for `list_project_deals` — use `get_project_services` instead.
+- Task status updates require workflow_status_id (not simple strings). Use `list_workflow_statuses` first.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -595,13 +595,18 @@ export class ProductiveAPIClient {
    */
   async listServices(params?: {
     company_id?: string;
+    project_id?: string;
     limit?: number;
     page?: number;
   }): Promise<ProductiveResponse<ProductiveService>> {
     const queryParams = new URLSearchParams();
-    
+
     if (params?.company_id) {
       queryParams.append('filter[company_id]', params.company_id);
+    }
+
+    if (params?.project_id) {
+      queryParams.append('filter[project_id]', params.project_id);
     }
     
     if (params?.limit) {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,8 +1,8 @@
 import { Config } from '../config/index.js';
-import { 
-  ProductiveCompany, 
-  ProductiveProject, 
-  ProductiveTask, 
+import {
+  ProductiveCompany,
+  ProductiveProject,
+  ProductiveTask,
   ProductiveBoard,
   ProductiveTaskList,
   ProductivePerson,
@@ -12,7 +12,7 @@ import {
   ProductiveService,
   ProductiveTimeEntry,
   ProductiveDeal,
-  ProductiveResponse, 
+  ProductiveResponse,
   ProductiveSingleResponse,
   ProductiveTaskCreate,
   ProductiveTaskUpdate,
@@ -20,7 +20,8 @@ import {
   ProductiveTaskListCreate,
   ProductiveCommentCreate,
   ProductiveTimeEntryCreate,
-  ProductiveError 
+  ProductiveTimeEntryUpdate,
+  ProductiveError
 } from './types.js';
 
 export class ProductiveAPIClient {
@@ -482,12 +483,30 @@ export class ProductiveAPIClient {
    * });
    */
   async createTimeEntry(timeEntryData: ProductiveTimeEntryCreate): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
-    // Debug: Log the request body
-    console.error('Creating time entry with data:', JSON.stringify(timeEntryData, null, 2));
     return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>('time_entries', {
       method: 'POST',
       body: JSON.stringify(timeEntryData),
     });
+  }
+
+  async updateTimeEntry(timeEntryData: ProductiveTimeEntryUpdate): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(`time_entries/${timeEntryData.data.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(timeEntryData),
+    });
+  }
+
+  async deleteTimeEntry(timeEntryId: string): Promise<void> {
+    const url = `${this.config.PRODUCTIVE_API_BASE_URL}time_entries/${timeEntryId}`;
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: this.getHeaders(),
+    });
+    if (!response.ok) {
+      const errorData = await response.json() as ProductiveError;
+      const errorMessage = errorData.errors?.[0]?.detail || `Delete failed with status ${response.status}`;
+      throw new Error(errorMessage);
+    }
   }
 
   /**

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -510,6 +510,19 @@ export interface ProductiveTimeEntryCreate {
   };
 }
 
+export interface ProductiveTimeEntryUpdate {
+  data: {
+    type: 'time_entries';
+    id: string;
+    attributes: {
+      date?: string;
+      time?: number;
+      billable_time?: number;
+      note?: string;
+    };
+  };
+}
+
 export interface ProductiveError {
   errors: Array<{
     status?: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ import { getRecentUpdates, getRecentUpdatesTool } from './tools/recent-updates.j
 import { addTaskCommentTool, addTaskCommentDefinition } from './tools/comments.js';
 import { updateTaskStatusTool, updateTaskStatusDefinition } from './tools/task-status.js';
 import { listWorkflowStatusesTool, listWorkflowStatusesDefinition } from './tools/workflow-statuses.js';
-import { listTimeEntresTool, createTimeEntryTool, listServicesTool, getProjectServicesTool, listProjectDealsTool, listDealServicesTool, listTimeEntriesDefinition, createTimeEntryDefinition, listServicesDefinition, getProjectServicesDefinition, listProjectDealsDefinition, listDealServicesDefinition } from './tools/time-entries.js';
+import { listTimeEntresTool, createTimeEntryTool, updateTimeEntryTool, deleteTimeEntryTool, listServicesTool, getProjectServicesTool, listProjectDealsTool, listDealServicesTool, listTimeEntriesDefinition, createTimeEntryDefinition, updateTimeEntryDefinition, deleteTimeEntryDefinition, listServicesDefinition, getProjectServicesDefinition, listProjectDealsDefinition, listDealServicesDefinition } from './tools/time-entries.js';
 import { updateTaskSprint, updateTaskSprintTool } from './tools/task-sprint.js';
 import { moveTaskToList, moveTaskToListTool } from './tools/task-list-move.js';
 import { addToBacklog, addToBacklogTool } from './tools/task-backlog.js';
@@ -67,6 +67,8 @@ export async function createServer() {
       getRecentUpdatesTool,
       listTimeEntriesDefinition,
       createTimeEntryDefinition,
+      updateTimeEntryDefinition,
+      deleteTimeEntryDefinition,
       listProjectDealsDefinition,
       listDealServicesDefinition,
       listServicesDefinition,
@@ -144,7 +146,13 @@ export async function createServer() {
         
       case 'create_time_entry':
         return await createTimeEntryTool(apiClient, args, config);
-        
+
+      case 'update_time_entry':
+        return await updateTimeEntryTool(apiClient, args);
+
+      case 'delete_time_entry':
+        return await deleteTimeEntryTool(apiClient, args);
+
       case 'list_project_deals':
         return await listProjectDealsTool(apiClient, args);
         

--- a/src/tools/activities.ts
+++ b/src/tools/activities.ts
@@ -10,9 +10,9 @@ const ListActivitiesRequestSchema = z.object({
   event: z.string().optional(),
   after: z.string().optional(), // ISO 8601 date string
   before: z.string().optional(), // ISO 8601 date string
-  days_back: z.number().min(1).max(365).optional(), // Helper for "last N days"
-  limit: z.number().min(1).max(200).optional(),
-  page: z.number().min(1).optional(),
+  days_back: z.coerce.number().min(1).max(365).optional(), // Helper for "last N days"
+  limit: z.coerce.number().min(1).max(200).optional(),
+  page: z.coerce.number().min(1).optional(),
 });
 
 export async function listActivities(

--- a/src/tools/boards.ts
+++ b/src/tools/boards.ts
@@ -4,7 +4,7 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
 const ListBoardsSchema = z.object({
   project_id: z.string().optional().describe('Filter boards by project ID'),
-  limit: z.number().optional().default(30).describe('Number of boards to return (max 200)'),
+  limit: z.coerce.number().optional().default(30).describe('Number of boards to return (max 200)'),
 });
 
 export async function listBoards(

--- a/src/tools/companies.ts
+++ b/src/tools/companies.ts
@@ -4,7 +4,7 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
 const listCompaniesSchema = z.object({
   status: z.enum(['active', 'archived']).optional(),
-  limit: z.number().min(1).max(200).default(30).optional(),
+  limit: z.coerce.number().min(1).max(200).default(30).optional(),
 });
 
 export async function listCompaniesTool(

--- a/src/tools/my-tasks.ts
+++ b/src/tools/my-tasks.ts
@@ -5,7 +5,7 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
 const myTasksSchema = z.object({
   status: z.enum(['open', 'closed']).optional(),
-  limit: z.number().min(1).max(200).default(30).optional(),
+  limit: z.coerce.number().min(1).max(200).default(30).optional(),
 });
 
 export async function myTasksTool(

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -5,7 +5,7 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 const listProjectsSchema = z.object({
   status: z.enum(['active', 'archived']).optional(),
   company_id: z.string().optional(),
-  limit: z.number().min(1).max(200).default(30).optional(),
+  limit: z.coerce.number().min(1).max(200).default(30).optional(),
 });
 
 export async function listProjectsTool(

--- a/src/tools/recent-updates.ts
+++ b/src/tools/recent-updates.ts
@@ -4,8 +4,8 @@ import { ProductiveAPIClient } from '../api/client.js';
 
 const RecentUpdatesRequestSchema = z.object({
   project_id: z.string().optional(),
-  days_back: z.number().min(1).max(30).default(7),
-  limit: z.number().min(1).max(200).optional(),
+  days_back: z.coerce.number().min(1).max(30).default(7),
+  limit: z.coerce.number().min(1).max(200).optional(),
 });
 
 export async function getRecentUpdates(

--- a/src/tools/task-lists.ts
+++ b/src/tools/task-lists.ts
@@ -4,7 +4,7 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
 const ListTaskListsSchema = z.object({
   board_id: z.string().optional().describe('Filter task lists by board ID'),
-  limit: z.number().optional().default(30).describe('Number of task lists to return (max 200)'),
+  limit: z.coerce.number().optional().default(30).describe('Number of task lists to return (max 200)'),
 });
 
 export async function listTaskLists(

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -7,7 +7,7 @@ const listTasksSchema = z.object({
   project_id: z.string().optional(),
   assignee_id: z.string().optional(),
   status: z.enum(['open', 'closed']).optional(),
-  limit: z.number().min(1).max(200).default(30).optional(),
+  limit: z.coerce.number().min(1).max(200).default(30).optional(),
 });
 
 const getProjectTasksSchema = z.object({

--- a/src/tools/time-entries.ts
+++ b/src/tools/time-entries.ts
@@ -69,7 +69,7 @@ const listTimeEntriesSchema = z.object({
   project_id: z.string().optional(),
   task_id: z.string().optional(),
   service_id: z.string().optional(),
-  limit: z.number().min(1).max(200).default(30).optional(),
+  limit: z.coerce.number().min(1).max(200).default(30).optional(),
 });
 
 const createTimeEntrySchema = z.object({
@@ -85,12 +85,12 @@ const createTimeEntrySchema = z.object({
 
 const listServicesSchema = z.object({
   company_id: z.string().optional(),
-  limit: z.number().min(1).max(200).default(30).optional(),
+  limit: z.coerce.number().min(1).max(200).default(30).optional(),
 });
 
 const getProjectServicesSchema = z.object({
   project_id: z.string().min(1, 'Project ID is required'),
-  limit: z.number().min(1).max(200).default(30).optional(),
+  limit: z.coerce.number().min(1).max(200).default(30).optional(),
 });
 
 export async function listTimeEntresTool(
@@ -441,16 +441,9 @@ export async function getProjectServicesTool(
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = getProjectServicesSchema.parse(args);
-    
-    // First get the project to verify it exists and get company info
-    const projectResponse = await client.listProjects({
-      limit: 1,
-    });
-    
-    // Then get services for the project's company
-    // Note: This is a simplified approach - in practice you might need
-    // to get the project details first to find its company
+
     const response = await client.listServices({
+      project_id: params.project_id,
       limit: params.limit,
     });
     
@@ -610,8 +603,8 @@ export const listServicesDefinition = {
 // Zod schema for list project deals/budgets
 const listProjectDealsSchema = z.object({
   project_id: z.string().min(1, 'Project ID is required'),
-  budget_type: z.number().int().min(1).max(2).optional().describe('Budget type: 1 = deal, 2 = budget'),
-  limit: z.number().min(1).max(200).default(30).optional(),
+  budget_type: z.coerce.number().int().min(1).max(2).optional().describe('Budget type: 1 = deal, 2 = budget'),
+  limit: z.coerce.number().min(1).max(200).default(30).optional(),
 });
 
 // Tool function for list project deals/budgets
@@ -675,7 +668,7 @@ export async function listProjectDealsTool(
 // Zod schema for list deal services
 const listDealServicesSchema = z.object({
   deal_id: z.string().min(1, 'Deal/Budget ID is required'),
-  limit: z.number().min(1).max(200).default(30).optional(),
+  limit: z.coerce.number().min(1).max(200).default(30).optional(),
 });
 
 // Tool function for list deal services

--- a/src/tools/time-entries.ts
+++ b/src/tools/time-entries.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { ProductiveTimeEntryCreate } from '../api/types.js';
+import { ProductiveTimeEntryCreate, ProductiveTimeEntryUpdate } from '../api/types.js';
 
 // Helper function to parse time input into minutes
 function parseTimeToMinutes(timeInput: string): number {
@@ -597,6 +597,209 @@ export const listServicesDefinition = {
       },
     },
     required: [],
+  },
+};
+
+const updateTimeEntrySchema = z.object({
+  time_entry_id: z.string().min(1, 'Time entry ID is required'),
+  date: z.string().optional(),
+  time: z.string().optional(),
+  note: z.string().optional(),
+  billable_time: z.string().optional(),
+  confirm: z.boolean().optional().default(false),
+});
+
+const deleteTimeEntrySchema = z.object({
+  time_entry_id: z.string().min(1, 'Time entry ID is required'),
+  confirm: z.boolean().optional().default(false),
+});
+
+export async function updateTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = updateTimeEntrySchema.parse(args);
+
+    // Parse time if provided
+    let timeInMinutes: number | undefined;
+    if (params.time) {
+      timeInMinutes = parseTimeToMinutes(params.time);
+    }
+
+    // Parse billable time if provided
+    let billableTimeInMinutes: number | undefined;
+    if (params.billable_time) {
+      billableTimeInMinutes = parseTimeToMinutes(params.billable_time);
+    }
+
+    // Parse date if provided
+    let parsedDate: string | undefined;
+    if (params.date) {
+      parsedDate = parseDate(params.date);
+    }
+
+    if (!params.confirm) {
+      const changes: string[] = [];
+      if (parsedDate) changes.push(`Date: ${parsedDate}`);
+      if (timeInMinutes !== undefined) {
+        const h = Math.floor(timeInMinutes / 60);
+        const m = timeInMinutes % 60;
+        changes.push(`Time: ${h > 0 ? (m > 0 ? `${h}h ${m}m` : `${h}h`) : `${m}m`}`);
+      }
+      if (billableTimeInMinutes !== undefined) {
+        const h = Math.floor(billableTimeInMinutes / 60);
+        const m = billableTimeInMinutes % 60;
+        changes.push(`Billable Time: ${h > 0 ? (m > 0 ? `${h}h ${m}m` : `${h}h`) : `${m}m`}`);
+      }
+      if (params.note !== undefined) changes.push(`Note: ${params.note}`);
+
+      if (changes.length === 0) {
+        return {
+          content: [{ type: 'text', text: 'No changes specified. Provide at least one field to update (date, time, note, billable_time).' }],
+        };
+      }
+
+      return {
+        content: [{
+          type: 'text',
+          text: `Update Time Entry ${params.time_entry_id}:\n\n${changes.join('\n')}\n\nTo apply, call this tool again with the same parameters and add "confirm": true`,
+        }],
+      };
+    }
+
+    const updateData: ProductiveTimeEntryUpdate = {
+      data: {
+        type: 'time_entries',
+        id: params.time_entry_id,
+        attributes: {
+          ...(parsedDate && { date: parsedDate }),
+          ...(timeInMinutes !== undefined && { time: timeInMinutes }),
+          ...(billableTimeInMinutes !== undefined && { billable_time: billableTimeInMinutes }),
+          ...(params.note !== undefined && { note: params.note }),
+        },
+      },
+    };
+
+    const response = await client.updateTimeEntry(updateData);
+
+    const hours = Math.floor(response.data.attributes.time / 60);
+    const minutes = response.data.attributes.time % 60;
+    const timeDisplay = hours > 0
+      ? (minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`)
+      : `${minutes}m`;
+
+    return {
+      content: [{
+        type: 'text',
+        text: `Time entry ${response.data.id} updated successfully!\nDate: ${response.data.attributes.date}\nTime: ${timeDisplay}\nNote: ${response.data.attributes.note || 'No note'}`,
+      }],
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export async function deleteTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = deleteTimeEntrySchema.parse(args);
+
+    if (!params.confirm) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Are you sure you want to delete time entry ${params.time_entry_id}? This cannot be undone.\n\nTo confirm, call this tool again with "confirm": true`,
+        }],
+      };
+    }
+
+    await client.deleteTimeEntry(params.time_entry_id);
+
+    return {
+      content: [{
+        type: 'text',
+        text: `Time entry ${params.time_entry_id} deleted successfully.`,
+      }],
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export const updateTimeEntryDefinition = {
+  name: 'update_time_entry',
+  description: 'Update an existing time entry. Can modify date, time, note, and billable_time. Only works on entries that have not been submitted or approved. Requires confirmation before applying changes.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'The ID of the time entry to update (required)',
+      },
+      date: {
+        type: 'string',
+        description: 'New date. Accepts "today", "yesterday", or YYYY-MM-DD format',
+      },
+      time: {
+        type: 'string',
+        description: 'New time duration. Accepts "2h", "120m", "2.5h", or "2.5" (assumed hours)',
+      },
+      note: {
+        type: 'string',
+        description: 'New work description',
+      },
+      billable_time: {
+        type: 'string',
+        description: 'New billable time duration, same format as time field',
+      },
+      confirm: {
+        type: 'boolean',
+        description: 'Set to true to confirm and apply the update. First call without this to see what will change.',
+        default: false,
+      },
+    },
+    required: ['time_entry_id'],
+  },
+};
+
+export const deleteTimeEntryDefinition = {
+  name: 'delete_time_entry',
+  description: 'Delete an existing time entry. This cannot be undone. Only works on entries that have not been submitted or approved. Requires confirmation before deleting.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'The ID of the time entry to delete (required)',
+      },
+      confirm: {
+        type: 'boolean',
+        description: 'Set to true to confirm deletion. First call without this to see confirmation prompt.',
+        default: false,
+      },
+    },
+    required: ['time_entry_id'],
   },
 };
 

--- a/src/tools/workflow-statuses.ts
+++ b/src/tools/workflow-statuses.ts
@@ -4,8 +4,8 @@ import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 
 const listWorkflowStatusesSchema = z.object({
   workflow_id: z.string().optional(),
-  category_id: z.number().int().min(1).max(3).optional(),
-  limit: z.number().min(1).max(200).default(50).optional(),
+  category_id: z.coerce.number().int().min(1).max(3).optional(),
+  limit: z.coerce.number().min(1).max(200).default(50).optional(),
 });
 
 export async function listWorkflowStatusesTool(


### PR DESCRIPTION
## Summary

- **`get_project_services` now returns project-specific services** — the tool was ignoring the `project_id` input and calling `listServices()` with no filter, returning all org-wide services instead of only those belonging to the specified project's budget.
- **`listServices` API client method** now supports a `project_id` filter parameter, appending `filter[project_id]` to the query string.
- **All Zod schemas use `z.coerce.number()`** for numeric parameters (`limit`, `page`, `days_back`, `budget_type`, `category_id`) — the MCP protocol sends all values as strings, causing `z.number()` validation to reject valid inputs like `limit: 5`.

## Details

### `get_project_services` bug

The original implementation:
1. Called `listProjects({ limit: 1 })` (fetching one arbitrary project, ignoring the result)
2. Called `listServices({ limit: params.limit })` with no project filter

The fix passes `project_id` through to `listServices()`, which now appends `filter[project_id]` to the API request.

### Numeric coercion

The MCP protocol transmits all tool parameters as strings. Zod's `z.number()` rejects these with "Expected number, received string". Switching to `z.coerce.number()` automatically coerces string inputs to numbers before validation. This affects 10 files across all tool schemas.

## Test plan

- [ ] Verify `get_project_services` returns only services for the specified project (not all org services)
- [ ] Verify `list_tasks`, `list_activities`, `get_recent_updates` accept `limit` parameter without type errors
- [ ] Verify all other tools with numeric params still work as expected