### PR TITLE
feat: add time entry update and approval tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,95 @@ Parameters:
 - `limit` (optional): Maximum number of people to return (default: 50, max: 100)
 - `page` (optional): Page number for pagination (default: 1)
 
+### Time Management Tools
+
+Time entries track work performed against projects and services. Each entry belongs to a person, a service (within a deal/budget), and optionally a task. Time entries follow an approval workflow: they can be approved, unapproved, rejected (with a reason), or unrejected. To create a time entry, you need to follow the hierarchy: Project -> Deal/Budget -> Service -> Time Entry.
+
+#### list_time_entries
+View existing time entries with detailed information including service and budget relationships.
+
+Parameters:
+- `date` (optional): Filter by specific date (YYYY-MM-DD format)
+- `after` (optional): Filter entries after this date (YYYY-MM-DD format)
+- `before` (optional): Filter entries before this date (YYYY-MM-DD format)
+- `person_id` (optional): Filter by person ID (use "me" if PRODUCTIVE_USER_ID is configured)
+- `project_id` (optional): Filter by project ID
+- `task_id` (optional): Filter by task ID
+- `service_id` (optional): Filter by service ID
+- `limit` (optional): Number of time entries to return (1-200, default: 30)
+
+#### create_time_entry
+Create a time entry with detailed work description. Requires confirmation before creating.
+
+Parameters:
+- `date` (required): Date for the time entry ("today", "yesterday", or YYYY-MM-DD)
+- `time` (required): Time duration ("2h", "120m", "2.5h", or "2.5")
+- `person_id` (required): ID of the person logging time (use "me" if configured)
+- `service_id` (required): ID of the service being performed
+- `note` (required): Detailed description of work performed (minimum 10 characters)
+- `task_id` (optional): ID of the task being worked on
+- `billable_time` (optional): Billable time duration, same formats as time
+- `confirm` (optional): Set to true to confirm and create the entry
+
+#### update_time_entry
+Update an existing time entry. All fields except time_entry_id are optional — only provided fields will be updated.
+
+Parameters:
+- `time_entry_id` (required): ID of the time entry to update
+- `date` (optional): New date ("today", "yesterday", or YYYY-MM-DD)
+- `time` (optional): New time duration ("2h", "120m", "2.5h", or "2.5")
+- `billable_time` (optional): New billable time duration
+- `note` (optional): Updated work description
+
+#### approve_time_entry
+Approve a time entry.
+
+Parameters:
+- `time_entry_id` (required): ID of the time entry to approve
+
+#### unapprove_time_entry
+Reverse approval of a time entry.
+
+Parameters:
+- `time_entry_id` (required): ID of the time entry to unapprove
+
+#### reject_time_entry
+Reject a time entry with an optional reason.
+
+Parameters:
+- `time_entry_id` (required): ID of the time entry to reject
+- `rejected_reason` (optional): Reason for rejecting the time entry
+
+#### unreject_time_entry
+Reverse rejection of a time entry.
+
+Parameters:
+- `time_entry_id` (required): ID of the time entry to unreject
+
+### Budget & Service Tools
+
+#### list_project_deals
+Get deals/budgets for a specific project. Step 2 of the timesheet workflow.
+
+Parameters:
+- `project_id` (required): The ID of the project
+- `budget_type` (optional): Filter by budget type (1 = deal, 2 = budget)
+- `limit` (optional): Number of deals/budgets to return (1-200, default: 30)
+
+#### list_deal_services
+Get services for a specific deal/budget. Step 3 of the timesheet workflow.
+
+Parameters:
+- `deal_id` (required): The ID of the deal/budget
+- `limit` (optional): Number of services to return (1-200, default: 30)
+
+#### list_services
+List all services in the organization.
+
+Parameters:
+- `company_id` (optional): Filter services by company ID
+- `limit` (optional): Number of services to return (1-200, default: 30)
+
 ### Activity & Updates Tools
 
 #### list_activities
@@ -364,6 +453,35 @@ Parameters:
 
 ## Common Workflows
 
+### Creating a Time Entry
+
+To create a time entry, follow the hierarchy: Project -> Deal/Budget -> Service -> Time Entry.
+
+1. **Find the project**: `list_projects`
+2. **Get deals/budgets**: `list_project_deals { "project_id": "..." }`
+3. **Get services**: `list_deal_services { "deal_id": "..." }`
+4. **Optionally find a task**: `get_project_tasks { "project_id": "..." }`
+5. **Create the entry**:
+   ```
+   create_time_entry {
+     "date": "today",
+     "time": "2h",
+     "person_id": "me",
+     "service_id": "...",
+     "task_id": "...",
+     "note": "Implemented feature X with unit tests"
+   }
+   ```
+
+### Managing Time Entry Approvals
+
+```
+approve_time_entry { "time_entry_id": "123" }
+unapprove_time_entry { "time_entry_id": "123" }
+reject_time_entry { "time_entry_id": "123", "rejected_reason": "Wrong project" }
+unreject_time_entry { "time_entry_id": "123" }
+```
+
 ### Updating Task Status
 
 To update a task's status, you need to use workflow status IDs rather than simple "open"/"closed" values:
@@ -387,6 +505,8 @@ To update a task's status, you need to use workflow status IDs rather than simpl
 When `PRODUCTIVE_USER_ID` is configured, you can use "me" in several tools:
 - `create_task` with `"assignee_id": "me"`
 - `update_task_assignment` with `"assignee_id": "me"`
+- `list_time_entries` with `"person_id": "me"`
+- `create_time_entry` with `"person_id": "me"`
 - `my_tasks` to get your assigned tasks
 - `whoami` to verify your configured user context
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,27 @@
 {
   "name": "productive-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "productive-mcp",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",
         "dotenv": "^16.6.0",
         "zod": "^3.25.67"
       },
+      "bin": {
+        "productive-mcp": "build/index.js"
+      },
       "devDependencies": {
         "@types/node": "^24.0.4",
         "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -20,7 +20,8 @@ import {
   ProductiveTaskListCreate,
   ProductiveCommentCreate,
   ProductiveTimeEntryCreate,
-  ProductiveError 
+  ProductiveTimeEntryUpdate,
+  ProductiveError
 } from './types.js';
 
 export class ProductiveAPIClient {
@@ -632,6 +633,71 @@ export class ProductiveAPIClient {
    */
   async getTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
     return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(`time_entries/${timeEntryId}`);
+  }
+
+  /**
+   * Update an existing time entry's attributes
+   *
+   * @param timeEntryId - The ID of the time entry to update
+   * @param timeEntryData - The update payload
+   * @returns Promise resolving to the updated time entry
+   */
+  async updateTimeEntry(
+    timeEntryId: string,
+    timeEntryData: ProductiveTimeEntryUpdate
+  ): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      `time_entries/${timeEntryId}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(timeEntryData),
+      }
+    );
+  }
+
+  /**
+   * Approve a time entry
+   */
+  async approveTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      `time_entries/${timeEntryId}/approve`,
+      { method: 'PATCH' }
+    );
+  }
+
+  /**
+   * Unapprove a time entry (reverse approval)
+   */
+  async unapproveTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      `time_entries/${timeEntryId}/unapprove`,
+      { method: 'PATCH' }
+    );
+  }
+
+  /**
+   * Reject a time entry
+   */
+  async rejectTimeEntry(timeEntryId: string, rejectedReason?: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      `time_entries/${timeEntryId}/reject`,
+      {
+        method: 'PATCH',
+        body: rejectedReason
+          ? JSON.stringify({ data: { type: 'time_entries', id: timeEntryId, attributes: { rejected_reason: rejectedReason } } })
+          : undefined,
+      }
+    );
+  }
+
+  /**
+   * Unreject a time entry (reverse rejection)
+   */
+  async unrejectTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      `time_entries/${timeEntryId}/unreject`,
+      { method: 'PATCH' }
+    );
   }
 
   /**

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -518,6 +518,23 @@ export interface ProductiveTimeEntryCreate {
   };
 }
 
+/**
+ * Time entry update interface for Productive API
+ * Used for PATCH requests to update time entry attributes
+ */
+export interface ProductiveTimeEntryUpdate {
+  data: {
+    type: 'time_entries';
+    id: string;
+    attributes?: {
+      date?: string;
+      time?: number;
+      billable_time?: number;
+      note?: string;
+    };
+  };
+}
+
 export interface ProductiveError {
   errors: Array<{
     status?: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,8 @@ import { addTaskCommentTool, addTaskCommentDefinition } from './tools/comments.j
 import { updateTaskStatusTool, updateTaskStatusDefinition } from './tools/task-status.js';
 import { listWorkflowStatusesTool, listWorkflowStatusesDefinition } from './tools/workflow-statuses.js';
 import { listTimeEntresTool, createTimeEntryTool, listServicesTool, getProjectServicesTool, listProjectDealsTool, listDealServicesTool, listTimeEntriesDefinition, createTimeEntryDefinition, listServicesDefinition, getProjectServicesDefinition, listProjectDealsDefinition, listDealServicesDefinition } from './tools/time-entries.js';
+import { updateTimeEntryTool, updateTimeEntryDefinition } from './tools/time-entry-update.js';
+import { approveTimeEntryTool, approveTimeEntryDefinition, unapproveTimeEntryTool, unapproveTimeEntryDefinition, rejectTimeEntryTool, rejectTimeEntryDefinition, unrejectTimeEntryTool, unrejectTimeEntryDefinition } from './tools/time-entry-approval.js';
 import { updateTaskSprint, updateTaskSprintTool } from './tools/task-sprint.js';
 import { moveTaskToList, moveTaskToListTool } from './tools/task-list-move.js';
 import { addToBacklog, addToBacklogTool } from './tools/task-backlog.js';
@@ -71,6 +73,11 @@ export async function createServer() {
       listDealServicesDefinition,
       listServicesDefinition,
       getProjectServicesDefinition,
+      updateTimeEntryDefinition,
+      approveTimeEntryDefinition,
+      unapproveTimeEntryDefinition,
+      rejectTimeEntryDefinition,
+      unrejectTimeEntryDefinition,
       updateTaskSprintTool,
       moveTaskToListTool,
       addToBacklogTool,
@@ -156,7 +163,22 @@ export async function createServer() {
         
       case 'get_project_services':
         return await getProjectServicesTool(apiClient, args);
-        
+
+      case 'update_time_entry':
+        return await updateTimeEntryTool(apiClient, args);
+
+      case 'approve_time_entry':
+        return await approveTimeEntryTool(apiClient, args);
+
+      case 'unapprove_time_entry':
+        return await unapproveTimeEntryTool(apiClient, args);
+
+      case 'reject_time_entry':
+        return await rejectTimeEntryTool(apiClient, args);
+
+      case 'unreject_time_entry':
+        return await unrejectTimeEntryTool(apiClient, args);
+
       case 'update_task_sprint':
         return await updateTaskSprint(apiClient, args);
         

--- a/src/tools/time-entries.ts
+++ b/src/tools/time-entries.ts
@@ -3,8 +3,18 @@ import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { ProductiveTimeEntryCreate } from '../api/types.js';
 
+// Helper function to format minutes into a human-readable display string
+export function formatMinutesDisplay(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return `${minutes}m`;
+}
+
 // Helper function to parse time input into minutes
-function parseTimeToMinutes(timeInput: string): number {
+export function parseTimeToMinutes(timeInput: string): number {
   const input = timeInput.toLowerCase().trim();
   
   // Handle hour formats: "2h", "2.5h", "2 hours"
@@ -29,7 +39,7 @@ function parseTimeToMinutes(timeInput: string): number {
 }
 
 // Helper function to parse date input
-function parseDate(dateInput: string): string {
+export function parseDate(dateInput: string): string {
   const input = dateInput.toLowerCase().trim();
   const today = new Date();
   

--- a/src/tools/time-entries.ts
+++ b/src/tools/time-entries.ts
@@ -149,20 +149,11 @@ export async function listTimeEntresTool(
       const taskId = entry.relationships?.task?.data?.id;
       const projectId = entry.relationships?.project?.data?.id;
       
-      const hours = Math.floor(entry.attributes.time / 60);
-      const minutes = entry.attributes.time % 60;
-      const timeDisplay = hours > 0 
-        ? (minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`)
-        : `${minutes}m`;
-      
+      const timeDisplay = formatMinutesDisplay(entry.attributes.time);
+
       let billableDisplay = '';
       if (entry.attributes.billable_time !== undefined && entry.attributes.billable_time !== entry.attributes.time) {
-        const billableHours = Math.floor(entry.attributes.billable_time / 60);
-        const billableMinutes = entry.attributes.billable_time % 60;
-        const billableTimeDisplay = billableHours > 0 
-          ? (billableMinutes > 0 ? `${billableHours}h ${billableMinutes}m` : `${billableHours}h`)
-          : `${billableMinutes}m`;
-        billableDisplay = ` (Billable: ${billableTimeDisplay})`;
+        billableDisplay = ` (Billable: ${formatMinutesDisplay(entry.attributes.billable_time)})`;
       }
       
       return `• Time Entry (ID: ${entry.id})
@@ -176,11 +167,7 @@ export async function listTimeEntresTool(
     }).join('\n\n');
     
     const totalMinutes = response.data.reduce((sum, entry) => sum + entry.attributes.time, 0);
-    const totalHours = Math.floor(totalMinutes / 60);
-    const totalMins = totalMinutes % 60;
-    const totalDisplay = totalHours > 0 
-      ? (totalMins > 0 ? `${totalHours}h ${totalMins}m` : `${totalHours}h`)
-      : `${totalMins}m`;
+    const totalDisplay = formatMinutesDisplay(totalMinutes);
     
     const summary = `Found ${response.data.length} time entr${response.data.length !== 1 ? 'ies' : 'y'}${response.meta?.total_count ? ` (showing ${response.data.length} of ${response.meta.total_count})` : ''}:\n\nTotal Time: ${totalDisplay}\n\n${entriesText}`;
     
@@ -262,20 +249,11 @@ export async function createTimeEntryTool(
     
     // If not confirmed, show confirmation details
     if (!params.confirm) {
-      const hours = Math.floor(timeInMinutes / 60);
-      const minutes = timeInMinutes % 60;
-      const timeDisplay = hours > 0 
-        ? (minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`)
-        : `${minutes}m`;
-      
+      const timeDisplay = formatMinutesDisplay(timeInMinutes);
+
       let billableDisplay = '';
       if (billableTimeInMinutes !== undefined) {
-        const billableHours = Math.floor(billableTimeInMinutes / 60);
-        const billableMins = billableTimeInMinutes % 60;
-        const billableTimeDisplay = billableHours > 0 
-          ? (billableMins > 0 ? `${billableHours}h ${billableMins}m` : `${billableHours}h`)
-          : `${billableMins}m`;
-        billableDisplay = `\nBillable Time: ${billableTimeDisplay}`;
+        billableDisplay = `\nBillable Time: ${formatMinutesDisplay(billableTimeInMinutes)}`;
       }
       
       return {
@@ -333,20 +311,11 @@ To create this time entry, call this tool again with the same parameters and add
     
     const response = await client.createTimeEntry(timeEntryData);
     
-    const hours = Math.floor(response.data.attributes.time / 60);
-    const minutes = response.data.attributes.time % 60;
-    const timeDisplay = hours > 0 
-      ? (minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`)
-      : `${minutes}m`;
-    
+    const timeDisplay = formatMinutesDisplay(response.data.attributes.time);
+
     let billableDisplay = '';
     if (response.data.attributes.billable_time !== undefined && response.data.attributes.billable_time !== response.data.attributes.time) {
-      const billableHours = Math.floor(response.data.attributes.billable_time / 60);
-      const billableMins = response.data.attributes.billable_time % 60;
-      const billableTimeDisplay = billableHours > 0 
-        ? (billableMins > 0 ? `${billableHours}h ${billableMins}m` : `${billableHours}h`)
-        : `${billableMins}m`;
-      billableDisplay = `\nBillable Time: ${billableTimeDisplay}`;
+      billableDisplay = `\nBillable Time: ${formatMinutesDisplay(response.data.attributes.billable_time)}`;
     }
     
     let text = `Time entry created successfully!

--- a/src/tools/time-entry-approval.ts
+++ b/src/tools/time-entry-approval.ts
@@ -1,0 +1,192 @@
+import { z } from 'zod';
+import { ProductiveAPIClient } from '../api/client.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ProductiveTimeEntry } from '../api/types.js';
+import { formatMinutesDisplay } from './time-entries.js';
+
+const timeEntryIdSchema = z.object({
+  time_entry_id: z.string().min(1, 'Time entry ID is required'),
+});
+
+const rejectTimeEntrySchema = z.object({
+  time_entry_id: z.string().min(1, 'Time entry ID is required'),
+  rejected_reason: z.string().optional(),
+});
+
+function formatTimeEntryResponse(action: string, entry: ProductiveTimeEntry, extra?: string): { content: Array<{ type: string; text: string }> } {
+  let text = `Time entry ${action}!\n`;
+  text += `ID: ${entry.id}\n`;
+  text += `Date: ${entry.attributes.date}\n`;
+  text += `Time: ${formatMinutesDisplay(entry.attributes.time)}`;
+
+  if (extra) {
+    text += `\n${extra}`;
+  }
+
+  if (entry.attributes.note) {
+    text += `\nNote: ${entry.attributes.note}`;
+  }
+
+  if (entry.attributes.updated_at) {
+    text += `\nUpdated at: ${entry.attributes.updated_at}`;
+  }
+
+  return { content: [{ type: 'text', text }] };
+}
+
+export async function approveTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = timeEntryIdSchema.parse(args);
+    const response = await client.approveTimeEntry(params.time_entry_id);
+    return formatTimeEntryResponse('approved successfully', response.data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export async function unapproveTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = timeEntryIdSchema.parse(args);
+    const response = await client.unapproveTimeEntry(params.time_entry_id);
+    return formatTimeEntryResponse('unapproved successfully', response.data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export async function rejectTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = rejectTimeEntrySchema.parse(args);
+    const response = await client.rejectTimeEntry(params.time_entry_id, params.rejected_reason);
+    const extra = params.rejected_reason ? `Reason: ${params.rejected_reason}` : undefined;
+    return formatTimeEntryResponse('rejected', response.data, extra);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export async function unrejectTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = timeEntryIdSchema.parse(args);
+    const response = await client.unrejectTimeEntry(params.time_entry_id);
+    return formatTimeEntryResponse('unrejected successfully', response.data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export const approveTimeEntryDefinition = {
+  name: 'approve_time_entry',
+  description: 'Approve a time entry in Productive.io. Use list_time_entries to find the time entry ID first.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'ID of the time entry to approve (required)',
+      },
+    },
+    required: ['time_entry_id'],
+  },
+};
+
+export const unapproveTimeEntryDefinition = {
+  name: 'unapprove_time_entry',
+  description: 'Unapprove (reverse approval of) a time entry in Productive.io. Use list_time_entries to find the time entry ID first.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'ID of the time entry to unapprove (required)',
+      },
+    },
+    required: ['time_entry_id'],
+  },
+};
+
+export const rejectTimeEntryDefinition = {
+  name: 'reject_time_entry',
+  description: 'Reject a time entry in Productive.io with an optional reason. Use list_time_entries to find the time entry ID first.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'ID of the time entry to reject (required)',
+      },
+      rejected_reason: {
+        type: 'string',
+        description: 'Reason for rejecting the time entry (optional)',
+      },
+    },
+    required: ['time_entry_id'],
+  },
+};
+
+export const unrejectTimeEntryDefinition = {
+  name: 'unreject_time_entry',
+  description: 'Unreject (reverse rejection of) a time entry in Productive.io. Use list_time_entries to find the time entry ID first.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'ID of the time entry to unreject (required)',
+      },
+    },
+    required: ['time_entry_id'],
+  },
+};

--- a/src/tools/time-entry-update.ts
+++ b/src/tools/time-entry-update.ts
@@ -1,0 +1,147 @@
+import { z } from 'zod';
+import { ProductiveAPIClient } from '../api/client.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ProductiveTimeEntryUpdate } from '../api/types.js';
+import { parseTimeToMinutes, parseDate, formatMinutesDisplay } from './time-entries.js';
+
+const updateTimeEntrySchema = z.object({
+  time_entry_id: z.string().min(1, 'Time entry ID is required'),
+  date: z.string().optional(),
+  time: z.string().optional(),
+  billable_time: z.string().optional(),
+  note: z.string().optional(),
+});
+
+export async function updateTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = updateTimeEntrySchema.parse(args);
+
+    const attributes: Record<string, string | number> = {};
+
+    if (params.date !== undefined) {
+      try {
+        attributes.date = parseDate(params.date);
+      } catch (error) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          error instanceof Error ? error.message : 'Invalid date format'
+        );
+      }
+    }
+
+    if (params.time !== undefined) {
+      try {
+        attributes.time = parseTimeToMinutes(params.time);
+      } catch (error) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          error instanceof Error ? error.message : 'Invalid time format'
+        );
+      }
+    }
+
+    if (params.billable_time !== undefined) {
+      try {
+        attributes.billable_time = parseTimeToMinutes(params.billable_time);
+      } catch (error) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Invalid billable time format: ${error instanceof Error ? error.message : 'Invalid time format'}`
+        );
+      }
+    }
+
+    if (params.note !== undefined) {
+      attributes.note = params.note;
+    }
+
+    if (Object.keys(attributes).length === 0) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'At least one field to update must be provided (date, time, billable_time, or note)'
+      );
+    }
+
+    const updateData: ProductiveTimeEntryUpdate = {
+      data: {
+        type: 'time_entries',
+        id: params.time_entry_id,
+        attributes,
+      },
+    };
+
+    const response = await client.updateTimeEntry(params.time_entry_id, updateData);
+
+    const entry = response.data;
+    let text = `Time entry updated successfully!\n`;
+    text += `ID: ${entry.id}\n`;
+    text += `Date: ${entry.attributes.date}\n`;
+    text += `Time: ${formatMinutesDisplay(entry.attributes.time)}`;
+
+    if (entry.attributes.billable_time !== undefined && entry.attributes.billable_time !== entry.attributes.time) {
+      text += ` (Billable: ${formatMinutesDisplay(entry.attributes.billable_time)})`;
+    }
+
+    if (entry.attributes.note) {
+      text += `\nNote: ${entry.attributes.note}`;
+    }
+
+    if (entry.attributes.updated_at) {
+      text += `\nUpdated at: ${entry.attributes.updated_at}`;
+    }
+
+    return {
+      content: [{ type: 'text', text }],
+    };
+  } catch (error) {
+    if (error instanceof McpError) {
+      throw error;
+    }
+
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export const updateTimeEntryDefinition = {
+  name: 'update_time_entry',
+  description: 'Update an existing time entry in Productive.io. All fields except time_entry_id are optional - only provided fields will be updated. Use list_time_entries to find the time entry ID first.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'ID of the time entry to update (required)',
+      },
+      date: {
+        type: 'string',
+        description: 'New date. Accepts "today", "yesterday", or YYYY-MM-DD format',
+      },
+      time: {
+        type: 'string',
+        description: 'New time duration. Accepts formats like "2h", "120m", "2.5h", or "2.5" (assumed hours)',
+      },
+      billable_time: {
+        type: 'string',
+        description: 'New billable time duration. Same formats as time field',
+      },
+      note: {
+        type: 'string',
+        description: 'Updated work description',
+      },
+    },
+    required: ['time_entry_id'],
+  },
+};


### PR DESCRIPTION
## Summary

- Add `update_time_entry` tool for updating time entry attributes (date, time, billable_time, note)
- Add `approve_time_entry`, `unapprove_time_entry`, `reject_time_entry`, `unreject_time_entry` tools using dedicated API endpoints
- Extract shared `formatMinutesDisplay` helper and refactor all existing inline time formatting to use it

## Changes

- **New:** `src/tools/time-entry-update.ts` — sparse update tool with time/date parsing
- **New:** `src/tools/time-entry-approval.ts` — 4 approval workflow tools
- **Modified:** `src/api/types.ts` — `ProductiveTimeEntryUpdate` interface
- **Modified:** `src/api/client.ts` — 5 new client methods (update, approve, unapprove, reject, unreject)
- **Modified:** `src/tools/time-entries.ts` — exported helpers, added `formatMinutesDisplay`, refactored 8 inline formatters
- **Modified:** `src/server.ts` — registered 5 new tools

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Verify `update_time_entry` with different field combinations
- [ ] Verify approve/unapprove/reject/unreject against Productive.io API
- [ ] Verify `rejected_reason` is sent correctly on reject