### PR TITLE
feat: add timer tools (start, stop, get)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -339,6 +339,95 @@ Parameters:
 - `limit` (optional): Maximum number of people to return (default: 50, max: 100)
 - `page` (optional): Page number for pagination (default: 1)
 
+### Time Management Tools
+
+Time entries track work performed against projects and services. Each entry belongs to a person, a service (within a deal/budget), and optionally a task. Time entries follow an approval workflow: they can be approved, unapproved, rejected (with a reason), or unrejected. To create a time entry, you need to follow the hierarchy: Project -> Deal/Budget -> Service -> Time Entry.
+
+#### list_time_entries
+View existing time entries with detailed information including service and budget relationships.
+
+Parameters:
+- `date` (optional): Filter by specific date (YYYY-MM-DD format)
+- `after` (optional): Filter entries after this date (YYYY-MM-DD format)
+- `before` (optional): Filter entries before this date (YYYY-MM-DD format)
+- `person_id` (optional): Filter by person ID (use "me" if PRODUCTIVE_USER_ID is configured)
+- `project_id` (optional): Filter by project ID
+- `task_id` (optional): Filter by task ID
+- `service_id` (optional): Filter by service ID
+- `limit` (optional): Number of time entries to return (1-200, default: 30)
+
+#### create_time_entry
+Create a time entry with detailed work description. Requires confirmation before creating.
+
+Parameters:
+- `date` (required): Date for the time entry ("today", "yesterday", or YYYY-MM-DD)
+- `time` (required): Time duration ("2h", "120m", "2.5h", or "2.5")
+- `person_id` (required): ID of the person logging time (use "me" if configured)
+- `service_id` (required): ID of the service being performed
+- `note` (required): Detailed description of work performed (minimum 10 characters)
+- `task_id` (optional): ID of the task being worked on
+- `billable_time` (optional): Billable time duration, same formats as time
+- `confirm` (optional): Set to true to confirm and create the entry
+
+#### update_time_entry
+Update an existing time entry. All fields except time_entry_id are optional — only provided fields will be updated.
+
+Parameters:
+- `time_entry_id` (required): ID of the time entry to update
+- `date` (optional): New date ("today", "yesterday", or YYYY-MM-DD)
+- `time` (optional): New time duration ("2h", "120m", "2.5h", or "2.5")
+- `billable_time` (optional): New billable time duration
+- `note` (optional): Updated work description
+
+#### approve_time_entry
+Approve a time entry.
+
+Parameters:
+- `time_entry_id` (required): ID of the time entry to approve
+
+#### unapprove_time_entry
+Reverse approval of a time entry.
+
+Parameters:
+- `time_entry_id` (required): ID of the time entry to unapprove
+
+#### reject_time_entry
+Reject a time entry with an optional reason.
+
+Parameters:
+- `time_entry_id` (required): ID of the time entry to reject
+- `rejected_reason` (optional): Reason for rejecting the time entry
+
+#### unreject_time_entry
+Reverse rejection of a time entry.
+
+Parameters:
+- `time_entry_id` (required): ID of the time entry to unreject
+
+### Budget & Service Tools
+
+#### list_project_deals
+Get deals/budgets for a specific project. Step 2 of the timesheet workflow.
+
+Parameters:
+- `project_id` (required): The ID of the project
+- `budget_type` (optional): Filter by budget type (1 = deal, 2 = budget)
+- `limit` (optional): Number of deals/budgets to return (1-200, default: 30)
+
+#### list_deal_services
+Get services for a specific deal/budget. Step 3 of the timesheet workflow.
+
+Parameters:
+- `deal_id` (required): The ID of the deal/budget
+- `limit` (optional): Number of services to return (1-200, default: 30)
+
+#### list_services
+List all services in the organization.
+
+Parameters:
+- `company_id` (optional): Filter services by company ID
+- `limit` (optional): Number of services to return (1-200, default: 30)
+
 ### Activity & Updates Tools
 
 #### list_activities
@@ -364,6 +453,35 @@ Parameters:
 
 ## Common Workflows
 
+### Creating a Time Entry
+
+To create a time entry, follow the hierarchy: Project -> Deal/Budget -> Service -> Time Entry.
+
+1. **Find the project**: `list_projects`
+2. **Get deals/budgets**: `list_project_deals { "project_id": "..." }`
+3. **Get services**: `list_deal_services { "deal_id": "..." }`
+4. **Optionally find a task**: `get_project_tasks { "project_id": "..." }`
+5. **Create the entry**:
+   ```
+   create_time_entry {
+     "date": "today",
+     "time": "2h",
+     "person_id": "me",
+     "service_id": "...",
+     "task_id": "...",
+     "note": "Implemented feature X with unit tests"
+   }
+   ```
+
+### Managing Time Entry Approvals
+
+```
+approve_time_entry { "time_entry_id": "123" }
+unapprove_time_entry { "time_entry_id": "123" }
+reject_time_entry { "time_entry_id": "123", "rejected_reason": "Wrong project" }
+unreject_time_entry { "time_entry_id": "123" }
+```
+
 ### Updating Task Status
 
 To update a task's status, you need to use workflow status IDs rather than simple "open"/"closed" values:
@@ -387,6 +505,8 @@ To update a task's status, you need to use workflow status IDs rather than simpl
 When `PRODUCTIVE_USER_ID` is configured, you can use "me" in several tools:
 - `create_task` with `"assignee_id": "me"`
 - `update_task_assignment` with `"assignee_id": "me"`
+- `list_time_entries` with `"person_id": "me"`
+- `create_time_entry` with `"person_id": "me"`
 - `my_tasks` to get your assigned tasks
 - `whoami` to verify your configured user context
 

--- a/README.md
+++ b/README.md
@@ -428,6 +428,25 @@ Parameters:
 - `company_id` (optional): Filter services by company ID
 - `limit` (optional): Number of services to return (1-200, default: 30)
 
+#### start_timer
+Start a new timer for real-time time tracking. Provide either a service_id (creates a new time entry automatically) or a time_entry_id (attaches to an existing time entry).
+
+Parameters:
+- `service_id` (optional): Service ID to track time against (required if no time_entry_id)
+- `time_entry_id` (optional): Existing time entry ID to attach timer to (required if no service_id)
+
+#### stop_timer
+Stop a running timer. The tracked time will be added to the associated time entry.
+
+Parameters:
+- `timer_id` (required): ID of the timer to stop
+
+#### get_timer
+Get a timer's current status to check if it is still running.
+
+Parameters:
+- `timer_id` (required): ID of the timer to check
+
 ### Activity & Updates Tools
 
 #### list_activities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,27 @@
 {
   "name": "productive-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "productive-mcp",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",
         "dotenv": "^16.6.0",
         "zod": "^3.25.67"
       },
+      "bin": {
+        "productive-mcp": "build/index.js"
+      },
       "devDependencies": {
         "@types/node": "^24.0.4",
         "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "productive-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "productive-mcp",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@types/node": "^24.0.4",
+        "prettier": "^3.8.1",
         "typescript": "^5.8.3"
       },
       "engines": {
@@ -740,6 +741,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "productive-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.4",
+    "prettier": "^3.8.1",
     "typescript": "^5.8.3"
   }
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -21,6 +21,8 @@ import {
   ProductiveCommentCreate,
   ProductiveTimeEntryCreate,
   ProductiveTimeEntryUpdate,
+  ProductiveTimer,
+  ProductiveTimerCreate,
   ProductiveError
 } from './types.js';
 
@@ -696,6 +698,33 @@ export class ProductiveAPIClient {
   async unrejectTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
     return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
       `time_entries/${timeEntryId}/unreject`,
+      { method: 'PATCH' }
+    );
+  }
+
+  /**
+   * Get a timer by ID
+   */
+  async getTimer(timerId: string): Promise<ProductiveSingleResponse<ProductiveTimer>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimer>>(`timers/${timerId}`);
+  }
+
+  /**
+   * Create and start a new timer
+   */
+  async createTimer(timerData: ProductiveTimerCreate): Promise<ProductiveSingleResponse<ProductiveTimer>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimer>>('timers', {
+      method: 'POST',
+      body: JSON.stringify(timerData),
+    });
+  }
+
+  /**
+   * Stop a running timer
+   */
+  async stopTimer(timerId: string): Promise<ProductiveSingleResponse<ProductiveTimer>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimer>>(
+      `timers/${timerId}/stop`,
       { method: 'PATCH' }
     );
   }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -20,7 +20,8 @@ import {
   ProductiveTaskListCreate,
   ProductiveCommentCreate,
   ProductiveTimeEntryCreate,
-  ProductiveError 
+  ProductiveTimeEntryUpdate,
+  ProductiveError
 } from './types.js';
 
 export class ProductiveAPIClient {
@@ -632,6 +633,71 @@ export class ProductiveAPIClient {
    */
   async getTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
     return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(`time_entries/${timeEntryId}`);
+  }
+
+  /**
+   * Update an existing time entry's attributes
+   *
+   * @param timeEntryId - The ID of the time entry to update
+   * @param timeEntryData - The update payload
+   * @returns Promise resolving to the updated time entry
+   */
+  async updateTimeEntry(
+    timeEntryId: string,
+    timeEntryData: ProductiveTimeEntryUpdate
+  ): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      `time_entries/${timeEntryId}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(timeEntryData),
+      }
+    );
+  }
+
+  /**
+   * Approve a time entry
+   */
+  async approveTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      `time_entries/${timeEntryId}/approve`,
+      { method: 'PATCH' }
+    );
+  }
+
+  /**
+   * Unapprove a time entry (reverse approval)
+   */
+  async unapproveTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      `time_entries/${timeEntryId}/unapprove`,
+      { method: 'PATCH' }
+    );
+  }
+
+  /**
+   * Reject a time entry
+   */
+  async rejectTimeEntry(timeEntryId: string, rejectedReason?: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      `time_entries/${timeEntryId}/reject`,
+      {
+        method: 'PATCH',
+        body: rejectedReason
+          ? JSON.stringify({ data: { type: 'time_entries', id: timeEntryId, attributes: { rejected_reason: rejectedReason } } })
+          : undefined,
+      }
+    );
+  }
+
+  /**
+   * Unreject a time entry (reverse rejection)
+   */
+  async unrejectTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      `time_entries/${timeEntryId}/unreject`,
+      { method: 'PATCH' }
+    );
   }
 
   /**

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,8 +1,8 @@
-import { Config } from '../config/index.js';
-import { 
-  ProductiveCompany, 
-  ProductiveProject, 
-  ProductiveTask, 
+import { Config } from "../config/index.js";
+import {
+  ProductiveCompany,
+  ProductiveProject,
+  ProductiveTask,
   ProductiveBoard,
   ProductiveTaskList,
   ProductivePerson,
@@ -12,7 +12,7 @@ import {
   ProductiveService,
   ProductiveTimeEntry,
   ProductiveDeal,
-  ProductiveResponse, 
+  ProductiveResponse,
   ProductiveSingleResponse,
   ProductiveTaskCreate,
   ProductiveTaskUpdate,
@@ -23,27 +23,30 @@ import {
   ProductiveTimeEntryUpdate,
   ProductiveTimer,
   ProductiveTimerCreate,
-  ProductiveError
-} from './types.js';
+  ProductiveError,
+} from "./types.js";
 
 export class ProductiveAPIClient {
   private config: Config;
-  
+
   constructor(config: Config) {
     this.config = config;
   }
-  
+
   private getHeaders(): HeadersInit {
     return {
-      'X-Auth-Token': this.config.PRODUCTIVE_API_TOKEN,
-      'X-Organization-Id': this.config.PRODUCTIVE_ORG_ID,
-      'Content-Type': 'application/vnd.api+json',
+      "X-Auth-Token": this.config.PRODUCTIVE_API_TOKEN,
+      "X-Organization-Id": this.config.PRODUCTIVE_ORG_ID,
+      "Content-Type": "application/vnd.api+json",
     };
   }
-  
-  private async makeRequest<T>(path: string, options?: RequestInit): Promise<T> {
+
+  private async makeRequest<T>(
+    path: string,
+    options?: RequestInit,
+  ): Promise<T> {
     const url = `${this.config.PRODUCTIVE_API_BASE_URL}${path}`;
-    
+
     try {
       const response = await fetch(url, {
         ...options,
@@ -52,193 +55,210 @@ export class ProductiveAPIClient {
           ...options?.headers,
         },
       });
-      
+
       if (!response.ok) {
-        const errorData = await response.json() as ProductiveError;
+        const errorData = (await response.json()) as ProductiveError;
         // Debug: Log full error response
-        console.error('API Error Response:', JSON.stringify(errorData, null, 2));
-        console.error('Request was to:', url);
-        const errorMessage = errorData.errors?.[0]?.detail || `API request failed with status ${response.status}`;
+        console.error(
+          "API Error Response:",
+          JSON.stringify(errorData, null, 2),
+        );
+        console.error("Request was to:", url);
+        const errorMessage =
+          errorData.errors?.[0]?.detail ||
+          `API request failed with status ${response.status}`;
         throw new Error(errorMessage);
       }
-      
-      return await response.json() as T;
+
+      return (await response.json()) as T;
     } catch (error) {
       if (error instanceof Error) {
         throw error;
       }
-      throw new Error('Unknown error occurred while making API request');
+      throw new Error("Unknown error occurred while making API request");
     }
   }
-  
+
   async listCompanies(params?: {
-    status?: 'active' | 'archived';
+    status?: "active" | "archived";
     limit?: number;
     page?: number;
   }): Promise<ProductiveResponse<ProductiveCompany>> {
     const queryParams = new URLSearchParams();
-    
+
     if (params?.status) {
-      queryParams.append('filter[status]', params.status);
+      queryParams.append("filter[status]", params.status);
     }
-    
+
     if (params?.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
-    
+
     if (params?.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
-    
+
     const queryString = queryParams.toString();
-    const path = `companies${queryString ? `?${queryString}` : ''}`;
-    
+    const path = `companies${queryString ? `?${queryString}` : ""}`;
+
     return this.makeRequest<ProductiveResponse<ProductiveCompany>>(path);
   }
-  
+
   async listProjects(params?: {
-    status?: 'active' | 'archived';
+    status?: "active" | "archived";
     company_id?: string;
     limit?: number;
     page?: number;
   }): Promise<ProductiveResponse<ProductiveProject>> {
     const queryParams = new URLSearchParams();
-    
+
     if (params?.status) {
       // Convert status string to integer: active = 1, archived = 2
-      const statusValue = params.status === 'active' ? '1' : '2';
-      queryParams.append('filter[status]', statusValue);
+      const statusValue = params.status === "active" ? "1" : "2";
+      queryParams.append("filter[status]", statusValue);
     }
-    
+
     if (params?.company_id) {
-      queryParams.append('filter[company_id]', params.company_id);
+      queryParams.append("filter[company_id]", params.company_id);
     }
-    
+
     if (params?.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
-    
+
     if (params?.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
-    
+
     const queryString = queryParams.toString();
-    const path = `projects${queryString ? `?${queryString}` : ''}`;
-    
+    const path = `projects${queryString ? `?${queryString}` : ""}`;
+
     return this.makeRequest<ProductiveResponse<ProductiveProject>>(path);
   }
-  
+
   async listTasks(params?: {
     project_id?: string;
     assignee_id?: string;
-    status?: 'open' | 'closed';
+    status?: "open" | "closed";
     limit?: number;
     page?: number;
   }): Promise<ProductiveResponse<ProductiveTask>> {
     const queryParams = new URLSearchParams();
 
     // Include assignee and workflow status so we can resolve names
-    queryParams.append('include', 'assignee,workflow_status');
+    queryParams.append("include", "assignee,workflow_status");
 
     if (params?.project_id) {
-      queryParams.append('filter[project_id]', params.project_id);
+      queryParams.append("filter[project_id]", params.project_id);
     }
 
     if (params?.assignee_id) {
-      queryParams.append('filter[assignee_id]', params.assignee_id);
+      queryParams.append("filter[assignee_id]", params.assignee_id);
     }
 
     if (params?.status) {
       // Convert status names to integers: open = 1, closed = 2
-      const statusValue = params.status === 'open' ? '1' : '2';
-      queryParams.append('filter[status]', statusValue);
+      const statusValue = params.status === "open" ? "1" : "2";
+      queryParams.append("filter[status]", statusValue);
     }
 
     if (params?.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
 
     if (params?.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
 
     const queryString = queryParams.toString();
-    const path = `tasks${queryString ? `?${queryString}` : ''}`;
+    const path = `tasks${queryString ? `?${queryString}` : ""}`;
 
     return this.makeRequest<ProductiveResponse<ProductiveTask>>(path);
   }
-  
+
   async listBoards(params?: {
     project_id?: string;
     limit?: number;
     page?: number;
   }): Promise<ProductiveResponse<ProductiveBoard>> {
     const queryParams = new URLSearchParams();
-    
+
     if (params?.project_id) {
-      queryParams.append('filter[project_id]', params.project_id);
+      queryParams.append("filter[project_id]", params.project_id);
     }
-    
+
     if (params?.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
-    
+
     if (params?.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
-    
+
     const queryString = queryParams.toString();
-    const path = `boards${queryString ? `?${queryString}` : ''}`;
-    
+    const path = `boards${queryString ? `?${queryString}` : ""}`;
+
     return this.makeRequest<ProductiveResponse<ProductiveBoard>>(path);
   }
-  
-  async createBoard(boardData: ProductiveBoardCreate): Promise<ProductiveSingleResponse<ProductiveBoard>> {
-    return this.makeRequest<ProductiveSingleResponse<ProductiveBoard>>('boards', {
-      method: 'POST',
-      body: JSON.stringify(boardData),
-    });
+
+  async createBoard(
+    boardData: ProductiveBoardCreate,
+  ): Promise<ProductiveSingleResponse<ProductiveBoard>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveBoard>>(
+      "boards",
+      {
+        method: "POST",
+        body: JSON.stringify(boardData),
+      },
+    );
   }
-  
-  async createTask(taskData: ProductiveTaskCreate): Promise<ProductiveSingleResponse<ProductiveTask>> {
-    return this.makeRequest<ProductiveSingleResponse<ProductiveTask>>('tasks', {
-      method: 'POST',
+
+  async createTask(
+    taskData: ProductiveTaskCreate,
+  ): Promise<ProductiveSingleResponse<ProductiveTask>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTask>>("tasks", {
+      method: "POST",
       body: JSON.stringify(taskData),
     });
   }
-  
+
   async listTaskLists(params?: {
     board_id?: string;
     limit?: number;
     page?: number;
   }): Promise<ProductiveResponse<ProductiveTaskList>> {
     const queryParams = new URLSearchParams();
-    
+
     if (params?.board_id) {
-      queryParams.append('filter[board_id]', params.board_id);
+      queryParams.append("filter[board_id]", params.board_id);
     }
-    
+
     if (params?.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
-    
+
     if (params?.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
-    
+
     const queryString = queryParams.toString();
-    const path = `task_lists${queryString ? `?${queryString}` : ''}`;
-    
+    const path = `task_lists${queryString ? `?${queryString}` : ""}`;
+
     return this.makeRequest<ProductiveResponse<ProductiveTaskList>>(path);
   }
-  
-  async createTaskList(taskListData: ProductiveTaskListCreate): Promise<ProductiveSingleResponse<ProductiveTaskList>> {
-    return this.makeRequest<ProductiveSingleResponse<ProductiveTaskList>>('task_lists', {
-      method: 'POST',
-      body: JSON.stringify(taskListData),
-    });
+
+  async createTaskList(
+    taskListData: ProductiveTaskListCreate,
+  ): Promise<ProductiveSingleResponse<ProductiveTaskList>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTaskList>>(
+      "task_lists",
+      {
+        method: "POST",
+        body: JSON.stringify(taskListData),
+      },
+    );
   }
-  
+
   async listPeople(params?: {
     company_id?: string;
     project_id?: string;
@@ -248,46 +268,56 @@ export class ProductiveAPIClient {
     page?: number;
   }): Promise<ProductiveResponse<ProductivePerson>> {
     const queryParams = new URLSearchParams();
-    
+
     if (params?.company_id) {
-      queryParams.append('filter[company_id]', params.company_id);
+      queryParams.append("filter[company_id]", params.company_id);
     }
-    
+
     if (params?.project_id) {
-      queryParams.append('filter[project_id]', params.project_id);
+      queryParams.append("filter[project_id]", params.project_id);
     }
-    
+
     if (params?.is_active !== undefined) {
-      queryParams.append('filter[is_active]', params.is_active.toString());
+      queryParams.append("filter[is_active]", params.is_active.toString());
     }
-    
+
     if (params?.email) {
-      queryParams.append('filter[email]', params.email);
+      queryParams.append("filter[email]", params.email);
     }
-    
+
     if (params?.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
-    
+
     if (params?.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
-    
+
     const queryString = queryParams.toString();
-    const path = `people${queryString ? `?${queryString}` : ''}`;
-    
+    const path = `people${queryString ? `?${queryString}` : ""}`;
+
     return this.makeRequest<ProductiveResponse<ProductivePerson>>(path);
   }
-  
-  async getTask(taskId: string): Promise<ProductiveSingleResponse<ProductiveTask>> {
-    return this.makeRequest<ProductiveSingleResponse<ProductiveTask>>(`tasks/${taskId}`);
+
+  async getTask(
+    taskId: string,
+  ): Promise<ProductiveSingleResponse<ProductiveTask>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTask>>(
+      `tasks/${taskId}`,
+    );
   }
 
-  async updateTask(taskId: string, taskData: ProductiveTaskUpdate): Promise<ProductiveSingleResponse<ProductiveTask>> {
-    return this.makeRequest<ProductiveSingleResponse<ProductiveTask>>(`tasks/${taskId}`, {
-      method: 'PATCH',
-      body: JSON.stringify(taskData),
-    });
+  async updateTask(
+    taskId: string,
+    taskData: ProductiveTaskUpdate,
+  ): Promise<ProductiveSingleResponse<ProductiveTask>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTask>>(
+      `tasks/${taskId}`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(taskData),
+      },
+    );
   }
 
   async listActivities(params?: {
@@ -302,54 +332,59 @@ export class ProductiveAPIClient {
     page?: number;
   }): Promise<ProductiveResponse<ProductiveActivity>> {
     const queryParams = new URLSearchParams();
-    
+
     if (params?.task_id) {
-      queryParams.append('filter[task_id]', params.task_id);
+      queryParams.append("filter[task_id]", params.task_id);
     }
-    
+
     if (params?.project_id) {
-      queryParams.append('filter[project_id]', params.project_id);
+      queryParams.append("filter[project_id]", params.project_id);
     }
-    
+
     if (params?.person_id) {
-      queryParams.append('filter[person_id]', params.person_id);
+      queryParams.append("filter[person_id]", params.person_id);
     }
-    
+
     if (params?.item_type) {
-      queryParams.append('filter[item_type]', params.item_type);
+      queryParams.append("filter[item_type]", params.item_type);
     }
-    
+
     if (params?.event) {
-      queryParams.append('filter[event]', params.event);
+      queryParams.append("filter[event]", params.event);
     }
-    
+
     if (params?.after) {
-      queryParams.append('filter[after]', params.after);
+      queryParams.append("filter[after]", params.after);
     }
-    
+
     if (params?.before) {
-      queryParams.append('filter[before]', params.before);
+      queryParams.append("filter[before]", params.before);
     }
-    
+
     if (params?.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
-    
+
     if (params?.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
-    
+
     const queryString = queryParams.toString();
-    const path = `activities${queryString ? `?${queryString}` : ''}`;
-    
+    const path = `activities${queryString ? `?${queryString}` : ""}`;
+
     return this.makeRequest<ProductiveResponse<ProductiveActivity>>(path);
   }
 
-  async createComment(commentData: ProductiveCommentCreate): Promise<ProductiveSingleResponse<ProductiveComment>> {
-    return this.makeRequest<ProductiveSingleResponse<ProductiveComment>>('comments', {
-      method: 'POST',
-      body: JSON.stringify(commentData),
-    });
+  async createComment(
+    commentData: ProductiveCommentCreate,
+  ): Promise<ProductiveSingleResponse<ProductiveComment>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveComment>>(
+      "comments",
+      {
+        method: "POST",
+        body: JSON.stringify(commentData),
+      },
+    );
   }
 
   async listWorkflowStatuses(params?: {
@@ -359,32 +394,32 @@ export class ProductiveAPIClient {
     page?: number;
   }): Promise<ProductiveResponse<ProductiveWorkflowStatus>> {
     const queryParams = new URLSearchParams();
-    
+
     if (params?.workflow_id) {
-      queryParams.append('filter[workflow_id]', params.workflow_id);
+      queryParams.append("filter[workflow_id]", params.workflow_id);
     }
-    
+
     if (params?.category_id) {
-      queryParams.append('filter[category_id]', params.category_id.toString());
+      queryParams.append("filter[category_id]", params.category_id.toString());
     }
-    
+
     if (params?.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
-    
+
     if (params?.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
-    
+
     const queryString = queryParams.toString();
-    const path = `workflow_statuses${queryString ? `?${queryString}` : ''}`;
-    
+    const path = `workflow_statuses${queryString ? `?${queryString}` : ""}`;
+
     return this.makeRequest<ProductiveResponse<ProductiveWorkflowStatus>>(path);
   }
 
   /**
    * List time entries with optional filters
-   * 
+   *
    * @param params - Filter parameters for time entries
    * @param params.date - Filter by specific date (ISO format: YYYY-MM-DD)
    * @param params.after - Filter entries after this date (ISO format: YYYY-MM-DD)
@@ -396,7 +431,7 @@ export class ProductiveAPIClient {
    * @param params.limit - Number of results per page
    * @param params.page - Page number for pagination
    * @returns Promise resolving to paginated time entries response
-   * 
+   *
    * @example
    * // Get time entries for a specific person and date range
    * const entries = await client.listTimeEntries({
@@ -417,58 +452,58 @@ export class ProductiveAPIClient {
     page?: number;
   }): Promise<ProductiveResponse<ProductiveTimeEntry>> {
     const queryParams = new URLSearchParams();
-    
+
     // Include relationships by default
-    queryParams.append('include', 'person,service,task');
-    
+    queryParams.append("include", "person,service,task");
+
     if (params?.date) {
-      queryParams.append('filter[date]', params.date);
+      queryParams.append("filter[date]", params.date);
     }
-    
+
     if (params?.after) {
-      queryParams.append('filter[after]', params.after);
+      queryParams.append("filter[after]", params.after);
     }
-    
+
     if (params?.before) {
-      queryParams.append('filter[before]', params.before);
+      queryParams.append("filter[before]", params.before);
     }
-    
+
     if (params?.person_id) {
-      queryParams.append('filter[person_id]', params.person_id);
+      queryParams.append("filter[person_id]", params.person_id);
     }
-    
+
     if (params?.project_id) {
-      queryParams.append('filter[project_id]', params.project_id);
+      queryParams.append("filter[project_id]", params.project_id);
     }
-    
+
     if (params?.task_id) {
-      queryParams.append('filter[task_id]', params.task_id);
+      queryParams.append("filter[task_id]", params.task_id);
     }
-    
+
     if (params?.service_id) {
-      queryParams.append('filter[service_id]', params.service_id);
+      queryParams.append("filter[service_id]", params.service_id);
     }
-    
+
     if (params?.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
-    
+
     if (params?.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
-    
+
     const queryString = queryParams.toString();
-    const path = `time_entries${queryString ? `?${queryString}` : ''}`;
-    
+    const path = `time_entries${queryString ? `?${queryString}` : ""}`;
+
     return this.makeRequest<ProductiveResponse<ProductiveTimeEntry>>(path);
   }
 
   /**
    * Create a new time entry
-   * 
+   *
    * @param timeEntryData - Time entry creation data
    * @returns Promise resolving to the created time entry
-   * 
+   *
    * @example
    * // Create a time entry for a task
    * const timeEntry = await client.createTimeEntry({
@@ -487,25 +522,33 @@ export class ProductiveAPIClient {
    *   }
    * });
    */
-  async createTimeEntry(timeEntryData: ProductiveTimeEntryCreate): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+  async createTimeEntry(
+    timeEntryData: ProductiveTimeEntryCreate,
+  ): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
     // Debug: Log the request body
-    console.error('Creating time entry with data:', JSON.stringify(timeEntryData, null, 2));
-    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>('time_entries', {
-      method: 'POST',
-      body: JSON.stringify(timeEntryData),
-    });
+    console.error(
+      "Creating time entry with data:",
+      JSON.stringify(timeEntryData, null, 2),
+    );
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      "time_entries",
+      {
+        method: "POST",
+        body: JSON.stringify(timeEntryData),
+      },
+    );
   }
 
   /**
    * List deals/budgets for a specific project
-   * 
+   *
    * @param params - Filter parameters for deals
    * @param params.project_id - Filter by project ID (required)
    * @param params.budget_type - Filter by budget type (1: deal, 2: budget)
    * @param params.limit - Number of results per page
    * @param params.page - Page number for pagination
    * @returns Promise resolving to paginated deals response
-   * 
+   *
    * @example
    * // Get all deals/budgets for a project
    * const deals = await client.listProjectDeals({
@@ -520,40 +563,40 @@ export class ProductiveAPIClient {
     page?: number;
   }): Promise<ProductiveResponse<ProductiveDeal>> {
     const queryParams = new URLSearchParams();
-    
+
     // Include project relationship
-    queryParams.append('include', 'project');
-    
+    queryParams.append("include", "project");
+
     // Filter by project - deals endpoint expects array format
-    queryParams.append('filter[project_id]', params.project_id);
-    
+    queryParams.append("filter[project_id]", params.project_id);
+
     if (params.budget_type) {
-      queryParams.append('filter[budget_type]', params.budget_type.toString());
+      queryParams.append("filter[budget_type]", params.budget_type.toString());
     }
-    
+
     if (params.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
-    
+
     if (params.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
-    
+
     const queryString = queryParams.toString();
-    const path = `deals${queryString ? `?${queryString}` : ''}`;
-    
+    const path = `deals${queryString ? `?${queryString}` : ""}`;
+
     return this.makeRequest<ProductiveResponse<ProductiveDeal>>(path);
   }
 
   /**
    * List services available for a specific deal/budget
-   * 
+   *
    * @param params - Filter parameters for services
    * @param params.deal_id - Filter by deal/budget ID
    * @param params.limit - Number of results per page
    * @param params.page - Page number for pagination
    * @returns Promise resolving to paginated services response
-   * 
+   *
    * @example
    * // Get services for a specific deal/budget
    * const services = await client.listDealServices({
@@ -566,33 +609,33 @@ export class ProductiveAPIClient {
     page?: number;
   }): Promise<ProductiveResponse<ProductiveService>> {
     const queryParams = new URLSearchParams();
-    
+
     // Filter by deal/budget
-    queryParams.append('filter[deal_id]', params.deal_id);
-    
+    queryParams.append("filter[deal_id]", params.deal_id);
+
     if (params.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
-    
+
     if (params.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
-    
+
     const queryString = queryParams.toString();
-    const path = `services${queryString ? `?${queryString}` : ''}`;
-    
+    const path = `services${queryString ? `?${queryString}` : ""}`;
+
     return this.makeRequest<ProductiveResponse<ProductiveService>>(path);
   }
 
   /**
    * List services available for time tracking
-   * 
+   *
    * @param params - Filter parameters for services
    * @param params.company_id - Filter by company ID
    * @param params.limit - Number of results per page
    * @param params.page - Page number for pagination
    * @returns Promise resolving to paginated services response
-   * 
+   *
    * @example
    * // Get all services
    * const services = await client.listServices({
@@ -601,40 +644,52 @@ export class ProductiveAPIClient {
    */
   async listServices(params?: {
     company_id?: string;
+    budget_status?: number;
     limit?: number;
     page?: number;
   }): Promise<ProductiveResponse<ProductiveService>> {
     const queryParams = new URLSearchParams();
-    
+
     if (params?.company_id) {
-      queryParams.append('filter[company_id]', params.company_id);
+      queryParams.append("filter[company_id]", params.company_id);
     }
-    
+
+    if (params?.budget_status) {
+      queryParams.append(
+        "filter[budget_status]",
+        params.budget_status.toString(),
+      );
+    }
+
     if (params?.limit) {
-      queryParams.append('page[size]', params.limit.toString());
+      queryParams.append("page[size]", params.limit.toString());
     }
-    
+
     if (params?.page) {
-      queryParams.append('page[number]', params.page.toString());
+      queryParams.append("page[number]", params.page.toString());
     }
-    
+
     const queryString = queryParams.toString();
-    const path = `services${queryString ? `?${queryString}` : ''}`;
-    
+    const path = `services${queryString ? `?${queryString}` : ""}`;
+
     return this.makeRequest<ProductiveResponse<ProductiveService>>(path);
   }
 
   /**
    * Get a specific time entry by ID
-   * 
+   *
    * @param timeEntryId - The ID of the time entry to retrieve
    * @returns Promise resolving to the time entry
-   * 
+   *
    * @example
    * const timeEntry = await client.getTimeEntry('123');
    */
-  async getTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
-    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(`time_entries/${timeEntryId}`);
+  async getTimeEntry(
+    timeEntryId: string,
+  ): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
+      `time_entries/${timeEntryId}`,
+    );
   }
 
   /**
@@ -646,102 +701,139 @@ export class ProductiveAPIClient {
    */
   async updateTimeEntry(
     timeEntryId: string,
-    timeEntryData: ProductiveTimeEntryUpdate
+    timeEntryData: ProductiveTimeEntryUpdate,
   ): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
     return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
       `time_entries/${timeEntryId}`,
       {
-        method: 'PATCH',
+        method: "PATCH",
         body: JSON.stringify(timeEntryData),
-      }
+      },
     );
   }
 
   /**
    * Approve a time entry
    */
-  async approveTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+  async approveTimeEntry(
+    timeEntryId: string,
+  ): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
     return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
       `time_entries/${timeEntryId}/approve`,
-      { method: 'PATCH' }
+      { method: "PATCH" },
     );
   }
 
   /**
    * Unapprove a time entry (reverse approval)
    */
-  async unapproveTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+  async unapproveTimeEntry(
+    timeEntryId: string,
+  ): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
     return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
       `time_entries/${timeEntryId}/unapprove`,
-      { method: 'PATCH' }
+      { method: "PATCH" },
     );
   }
 
   /**
    * Reject a time entry
    */
-  async rejectTimeEntry(timeEntryId: string, rejectedReason?: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+  async rejectTimeEntry(
+    timeEntryId: string,
+    rejectedReason?: string,
+  ): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
     return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
       `time_entries/${timeEntryId}/reject`,
       {
-        method: 'PATCH',
+        method: "PATCH",
         body: rejectedReason
-          ? JSON.stringify({ data: { type: 'time_entries', id: timeEntryId, attributes: { rejected_reason: rejectedReason } } })
+          ? JSON.stringify({
+              data: {
+                type: "time_entries",
+                id: timeEntryId,
+                attributes: { rejected_reason: rejectedReason },
+              },
+            })
           : undefined,
-      }
+      },
     );
   }
 
   /**
    * Unreject a time entry (reverse rejection)
    */
-  async unrejectTimeEntry(timeEntryId: string): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
+  async unrejectTimeEntry(
+    timeEntryId: string,
+  ): Promise<ProductiveSingleResponse<ProductiveTimeEntry>> {
     return this.makeRequest<ProductiveSingleResponse<ProductiveTimeEntry>>(
       `time_entries/${timeEntryId}/unreject`,
-      { method: 'PATCH' }
+      { method: "PATCH" },
     );
   }
 
   /**
    * Get a timer by ID
    */
-  async getTimer(timerId: string): Promise<ProductiveSingleResponse<ProductiveTimer>> {
-    return this.makeRequest<ProductiveSingleResponse<ProductiveTimer>>(`timers/${timerId}`);
+  async getTimer(
+    timerId: string,
+  ): Promise<ProductiveSingleResponse<ProductiveTimer>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimer>>(
+      `timers/${timerId}`,
+    );
+  }
+
+  /**
+   * Get a timer by ID with time_entry relationship included
+   */
+  async getTimerWithTimeEntry(
+    timerId: string,
+  ): Promise<ProductiveSingleResponse<ProductiveTimer>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimer>>(
+      `timers/${timerId}?include=time_entry`,
+    );
   }
 
   /**
    * Create and start a new timer
    */
-  async createTimer(timerData: ProductiveTimerCreate): Promise<ProductiveSingleResponse<ProductiveTimer>> {
-    return this.makeRequest<ProductiveSingleResponse<ProductiveTimer>>('timers', {
-      method: 'POST',
-      body: JSON.stringify(timerData),
-    });
+  async createTimer(
+    timerData: ProductiveTimerCreate,
+  ): Promise<ProductiveSingleResponse<ProductiveTimer>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTimer>>(
+      "timers",
+      {
+        method: "POST",
+        body: JSON.stringify(timerData),
+      },
+    );
   }
 
   /**
    * Stop a running timer
    */
-  async stopTimer(timerId: string): Promise<ProductiveSingleResponse<ProductiveTimer>> {
+  async stopTimer(
+    timerId: string,
+  ): Promise<ProductiveSingleResponse<ProductiveTimer>> {
     return this.makeRequest<ProductiveSingleResponse<ProductiveTimer>>(
       `timers/${timerId}/stop`,
-      { method: 'PATCH' }
+      { method: "PATCH" },
     );
   }
 
   /**
    * Helper method to get time entries for a specific date range
    * Convenience wrapper around listTimeEntries with date filtering
-   * 
+   *
    * @param startDate - Start date in ISO format (YYYY-MM-DD)
    * @param endDate - End date in ISO format (YYYY-MM-DD)
    * @param additionalParams - Additional filter parameters
    * @returns Promise resolving to paginated time entries response
-   * 
+   *
    * @example
    * // Get all time entries for last week
    * const entries = await client.getTimeEntriesInDateRange(
-   *   '2023-01-01', 
+   *   '2023-01-01',
    *   '2023-01-07',
    *   { person_id: '123' }
    * );
@@ -756,22 +848,22 @@ export class ProductiveAPIClient {
       service_id?: string;
       limit?: number;
       page?: number;
-    }
+    },
   ): Promise<ProductiveResponse<ProductiveTimeEntry>> {
     return this.listTimeEntries({
       after: startDate,
       before: endDate,
-      ...additionalParams
+      ...additionalParams,
     });
   }
 
   /**
    * Helper method to get time entries for today
    * Convenience wrapper for getting current day's time entries
-   * 
+   *
    * @param additionalParams - Additional filter parameters
    * @returns Promise resolving to paginated time entries response
-   * 
+   *
    * @example
    * // Get today's time entries for a specific person
    * const todayEntries = await client.getTodayTimeEntries({
@@ -786,72 +878,76 @@ export class ProductiveAPIClient {
     limit?: number;
     page?: number;
   }): Promise<ProductiveResponse<ProductiveTimeEntry>> {
-    const today = new Date().toISOString().split('T')[0]; // Get YYYY-MM-DD format
+    const today = new Date().toISOString().split("T")[0]; // Get YYYY-MM-DD format
     return this.listTimeEntries({
       date: today,
-      ...additionalParams
+      ...additionalParams,
     });
   }
 
   /**
    * Reposition a task in a task list
-   * 
+   *
    * @param taskId - ID of the task to reposition
    * @param attributes - Positioning attributes (move_before_id and/or move_after_id)
    * @returns Promise resolving to the task response
-   * 
+   *
    * @example
    * // Position task 1 after task 2
    * await client.repositionTask('1', { move_after_id: '2' });
-   * 
+   *
    * // Position task 3 between tasks 1 and 2
    * await client.repositionTask('3', { move_after_id: '1', move_before_id: '2' });
    */
   async repositionTask(
-    taskId: string, 
-    attributes: { 
-      move_before_id?: string; 
+    taskId: string,
+    attributes: {
+      move_before_id?: string;
       move_after_id?: string;
       placement?: number;
-    }
+    },
   ): Promise<any> {
     const requestBody = {
       data: {
-        type: 'tasks',
-        attributes: { ...attributes }
-      }
+        type: "tasks",
+        attributes: { ...attributes },
+      },
     };
 
     // The reposition endpoint returns 204 No Content on success
     const url = `${this.config.PRODUCTIVE_API_BASE_URL}tasks/${taskId}/reposition`;
-    
+
     try {
       const response = await fetch(url, {
-        method: 'PATCH',
+        method: "PATCH",
         headers: {
-          'X-Auth-Token': this.config.PRODUCTIVE_API_TOKEN,
-          'X-Organization-Id': this.config.PRODUCTIVE_ORG_ID,
-          'Content-Type': 'application/vnd.api+json',
+          "X-Auth-Token": this.config.PRODUCTIVE_API_TOKEN,
+          "X-Organization-Id": this.config.PRODUCTIVE_ORG_ID,
+          "Content-Type": "application/vnd.api+json",
         },
         body: JSON.stringify(requestBody),
       });
-      
+
       if (!response.ok) {
         if (response.status === 404) {
-          throw new Error(`Task ${taskId} not found or cannot be repositioned.`);
+          throw new Error(
+            `Task ${taskId} not found or cannot be repositioned.`,
+          );
         }
-        throw new Error(`Reposition failed with status ${response.status}: ${response.statusText}`);
+        throw new Error(
+          `Reposition failed with status ${response.status}: ${response.statusText}`,
+        );
       }
-      
+
       // If 204 No Content (success), return a minimal success response
       if (response.status === 204) {
         return {
           success: true,
           taskId: taskId,
-          message: `Task ${taskId} repositioned successfully`
+          message: `Task ${taskId} repositioned successfully`,
         };
       }
-      
+
       // For any other success response with content, try to parse JSON
       try {
         return await response.json();
@@ -860,11 +956,11 @@ export class ProductiveAPIClient {
         return {
           success: true,
           taskId: taskId,
-          message: `Task ${taskId} repositioned successfully`
+          message: `Task ${taskId} repositioned successfully`,
         };
       }
     } catch (error) {
-      console.error('Error repositioning task:', error);
+      console.error("Error repositioning task:", error);
       throw error;
     }
   }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -518,6 +518,23 @@ export interface ProductiveTimeEntryCreate {
   };
 }
 
+/**
+ * Time entry update interface for Productive API
+ * Used for PATCH requests to update time entry attributes
+ */
+export interface ProductiveTimeEntryUpdate {
+  data: {
+    type: 'time_entries';
+    id: string;
+    attributes?: {
+      date?: string;
+      time?: number;
+      billable_time?: number;
+      note?: string;
+    };
+  };
+}
+
 export interface ProductiveError {
   errors: Array<{
     status?: string;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -535,6 +535,61 @@ export interface ProductiveTimeEntryUpdate {
   };
 }
 
+/**
+ * Timer entity interface for Productive API
+ * Represents a time tracking session on a time entry
+ */
+export interface ProductiveTimer {
+  id: string;
+  type: 'timers';
+  attributes: {
+    person_id: number;
+    started_at: string;
+    stopped_at: string | null;
+    total_time: number;
+  };
+  relationships?: {
+    organization?: {
+      data: {
+        id: string;
+        type: 'organizations';
+      };
+    };
+    time_entry?: {
+      meta?: { included: boolean };
+      data?: {
+        id: string;
+        type: 'time_entries';
+      };
+    };
+  };
+}
+
+/**
+ * Timer creation interface for Productive API
+ * Requires either a time_entry or service relationship
+ */
+export interface ProductiveTimerCreate {
+  data: {
+    type: 'timers';
+    attributes: Record<string, never>;
+    relationships: {
+      time_entry?: {
+        data: {
+          id: string;
+          type: 'time_entries';
+        };
+      };
+      service?: {
+        data: {
+          id: string;
+          type: 'services';
+        };
+      };
+    };
+  };
+}
+
 export interface ProductiveError {
   errors: Array<{
     status?: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,8 @@ import { addTaskCommentTool, addTaskCommentDefinition } from './tools/comments.j
 import { updateTaskStatusTool, updateTaskStatusDefinition } from './tools/task-status.js';
 import { listWorkflowStatusesTool, listWorkflowStatusesDefinition } from './tools/workflow-statuses.js';
 import { listTimeEntresTool, createTimeEntryTool, listServicesTool, getProjectServicesTool, listProjectDealsTool, listDealServicesTool, listTimeEntriesDefinition, createTimeEntryDefinition, listServicesDefinition, getProjectServicesDefinition, listProjectDealsDefinition, listDealServicesDefinition } from './tools/time-entries.js';
+import { updateTimeEntryTool, updateTimeEntryDefinition } from './tools/time-entry-update.js';
+import { approveTimeEntryTool, approveTimeEntryDefinition, unapproveTimeEntryTool, unapproveTimeEntryDefinition, rejectTimeEntryTool, rejectTimeEntryDefinition, unrejectTimeEntryTool, unrejectTimeEntryDefinition } from './tools/time-entry-approval.js';
 import { updateTaskSprint, updateTaskSprintTool } from './tools/task-sprint.js';
 import { moveTaskToList, moveTaskToListTool } from './tools/task-list-move.js';
 import { addToBacklog, addToBacklogTool } from './tools/task-backlog.js';
@@ -71,6 +73,11 @@ export async function createServer() {
       listDealServicesDefinition,
       listServicesDefinition,
       getProjectServicesDefinition,
+      updateTimeEntryDefinition,
+      approveTimeEntryDefinition,
+      unapproveTimeEntryDefinition,
+      rejectTimeEntryDefinition,
+      unrejectTimeEntryDefinition,
       updateTaskSprintTool,
       moveTaskToListTool,
       addToBacklogTool,
@@ -156,7 +163,22 @@ export async function createServer() {
         
       case 'get_project_services':
         return await getProjectServicesTool(apiClient, args);
-        
+
+      case 'update_time_entry':
+        return await updateTimeEntryTool(apiClient, args);
+
+      case 'approve_time_entry':
+        return await approveTimeEntryTool(apiClient, args);
+
+      case 'unapprove_time_entry':
+        return await unapproveTimeEntryTool(apiClient, args);
+
+      case 'reject_time_entry':
+        return await rejectTimeEntryTool(apiClient, args);
+
+      case 'unreject_time_entry':
+        return await unrejectTimeEntryTool(apiClient, args);
+
       case 'update_task_sprint':
         return await updateTaskSprint(apiClient, args);
         

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import { listWorkflowStatusesTool, listWorkflowStatusesDefinition } from './tool
 import { listTimeEntresTool, createTimeEntryTool, listServicesTool, getProjectServicesTool, listProjectDealsTool, listDealServicesTool, listTimeEntriesDefinition, createTimeEntryDefinition, listServicesDefinition, getProjectServicesDefinition, listProjectDealsDefinition, listDealServicesDefinition } from './tools/time-entries.js';
 import { updateTimeEntryTool, updateTimeEntryDefinition } from './tools/time-entry-update.js';
 import { approveTimeEntryTool, approveTimeEntryDefinition, unapproveTimeEntryTool, unapproveTimeEntryDefinition, rejectTimeEntryTool, rejectTimeEntryDefinition, unrejectTimeEntryTool, unrejectTimeEntryDefinition } from './tools/time-entry-approval.js';
+import { getTimerTool, getTimerDefinition, startTimerTool, startTimerDefinition, stopTimerTool, stopTimerDefinition } from './tools/timers.js';
 import { updateTaskSprint, updateTaskSprintTool } from './tools/task-sprint.js';
 import { moveTaskToList, moveTaskToListTool } from './tools/task-list-move.js';
 import { addToBacklog, addToBacklogTool } from './tools/task-backlog.js';
@@ -78,6 +79,9 @@ export async function createServer() {
       unapproveTimeEntryDefinition,
       rejectTimeEntryDefinition,
       unrejectTimeEntryDefinition,
+      getTimerDefinition,
+      startTimerDefinition,
+      stopTimerDefinition,
       updateTaskSprintTool,
       moveTaskToListTool,
       addToBacklogTool,
@@ -178,6 +182,15 @@ export async function createServer() {
 
       case 'unreject_time_entry':
         return await unrejectTimeEntryTool(apiClient, args);
+
+      case 'get_timer':
+        return await getTimerTool(apiClient, args);
+
+      case 'start_timer':
+        return await startTimerTool(apiClient, args);
+
+      case 'stop_timer':
+        return await stopTimerTool(apiClient, args);
 
       case 'update_task_sprint':
         return await updateTaskSprint(apiClient, args);

--- a/src/tools/time-entries.ts
+++ b/src/tools/time-entries.ts
@@ -3,8 +3,18 @@ import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { ProductiveTimeEntryCreate } from '../api/types.js';
 
+// Helper function to format minutes into a human-readable display string
+export function formatMinutesDisplay(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return `${minutes}m`;
+}
+
 // Helper function to parse time input into minutes
-function parseTimeToMinutes(timeInput: string): number {
+export function parseTimeToMinutes(timeInput: string): number {
   const input = timeInput.toLowerCase().trim();
   
   // Handle hour formats: "2h", "2.5h", "2 hours"
@@ -29,7 +39,7 @@ function parseTimeToMinutes(timeInput: string): number {
 }
 
 // Helper function to parse date input
-function parseDate(dateInput: string): string {
+export function parseDate(dateInput: string): string {
   const input = dateInput.toLowerCase().trim();
   const today = new Date();
   

--- a/src/tools/time-entries.ts
+++ b/src/tools/time-entries.ts
@@ -149,20 +149,11 @@ export async function listTimeEntresTool(
       const taskId = entry.relationships?.task?.data?.id;
       const projectId = entry.relationships?.project?.data?.id;
       
-      const hours = Math.floor(entry.attributes.time / 60);
-      const minutes = entry.attributes.time % 60;
-      const timeDisplay = hours > 0 
-        ? (minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`)
-        : `${minutes}m`;
-      
+      const timeDisplay = formatMinutesDisplay(entry.attributes.time);
+
       let billableDisplay = '';
       if (entry.attributes.billable_time !== undefined && entry.attributes.billable_time !== entry.attributes.time) {
-        const billableHours = Math.floor(entry.attributes.billable_time / 60);
-        const billableMinutes = entry.attributes.billable_time % 60;
-        const billableTimeDisplay = billableHours > 0 
-          ? (billableMinutes > 0 ? `${billableHours}h ${billableMinutes}m` : `${billableHours}h`)
-          : `${billableMinutes}m`;
-        billableDisplay = ` (Billable: ${billableTimeDisplay})`;
+        billableDisplay = ` (Billable: ${formatMinutesDisplay(entry.attributes.billable_time)})`;
       }
       
       return `• Time Entry (ID: ${entry.id})
@@ -176,11 +167,7 @@ export async function listTimeEntresTool(
     }).join('\n\n');
     
     const totalMinutes = response.data.reduce((sum, entry) => sum + entry.attributes.time, 0);
-    const totalHours = Math.floor(totalMinutes / 60);
-    const totalMins = totalMinutes % 60;
-    const totalDisplay = totalHours > 0 
-      ? (totalMins > 0 ? `${totalHours}h ${totalMins}m` : `${totalHours}h`)
-      : `${totalMins}m`;
+    const totalDisplay = formatMinutesDisplay(totalMinutes);
     
     const summary = `Found ${response.data.length} time entr${response.data.length !== 1 ? 'ies' : 'y'}${response.meta?.total_count ? ` (showing ${response.data.length} of ${response.meta.total_count})` : ''}:\n\nTotal Time: ${totalDisplay}\n\n${entriesText}`;
     
@@ -262,20 +249,11 @@ export async function createTimeEntryTool(
     
     // If not confirmed, show confirmation details
     if (!params.confirm) {
-      const hours = Math.floor(timeInMinutes / 60);
-      const minutes = timeInMinutes % 60;
-      const timeDisplay = hours > 0 
-        ? (minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`)
-        : `${minutes}m`;
-      
+      const timeDisplay = formatMinutesDisplay(timeInMinutes);
+
       let billableDisplay = '';
       if (billableTimeInMinutes !== undefined) {
-        const billableHours = Math.floor(billableTimeInMinutes / 60);
-        const billableMins = billableTimeInMinutes % 60;
-        const billableTimeDisplay = billableHours > 0 
-          ? (billableMins > 0 ? `${billableHours}h ${billableMins}m` : `${billableHours}h`)
-          : `${billableMins}m`;
-        billableDisplay = `\nBillable Time: ${billableTimeDisplay}`;
+        billableDisplay = `\nBillable Time: ${formatMinutesDisplay(billableTimeInMinutes)}`;
       }
       
       return {
@@ -333,20 +311,11 @@ To create this time entry, call this tool again with the same parameters and add
     
     const response = await client.createTimeEntry(timeEntryData);
     
-    const hours = Math.floor(response.data.attributes.time / 60);
-    const minutes = response.data.attributes.time % 60;
-    const timeDisplay = hours > 0 
-      ? (minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`)
-      : `${minutes}m`;
-    
+    const timeDisplay = formatMinutesDisplay(response.data.attributes.time);
+
     let billableDisplay = '';
     if (response.data.attributes.billable_time !== undefined && response.data.attributes.billable_time !== response.data.attributes.time) {
-      const billableHours = Math.floor(response.data.attributes.billable_time / 60);
-      const billableMins = response.data.attributes.billable_time % 60;
-      const billableTimeDisplay = billableHours > 0 
-        ? (billableMins > 0 ? `${billableHours}h ${billableMins}m` : `${billableHours}h`)
-        : `${billableMins}m`;
-      billableDisplay = `\nBillable Time: ${billableTimeDisplay}`;
+      billableDisplay = `\nBillable Time: ${formatMinutesDisplay(response.data.attributes.billable_time)}`;
     }
     
     let text = `Time entry created successfully!

--- a/src/tools/time-entries.ts
+++ b/src/tools/time-entries.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
-import { ProductiveAPIClient } from '../api/client.js';
-import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { ProductiveTimeEntryCreate } from '../api/types.js';
+import { z } from "zod";
+import { ProductiveAPIClient } from "../api/client.js";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { ProductiveTimeEntryCreate } from "../api/types.js";
 
 // Helper function to format minutes into a human-readable display string
 export function formatMinutesDisplay(totalMinutes: number): string {
@@ -16,59 +16,63 @@ export function formatMinutesDisplay(totalMinutes: number): string {
 // Helper function to parse time input into minutes
 export function parseTimeToMinutes(timeInput: string): number {
   const input = timeInput.toLowerCase().trim();
-  
+
   // Handle hour formats: "2h", "2.5h", "2 hours"
   const hourMatch = input.match(/^(\d*\.?\d+)\s*h(?:ours?)?$/);
   if (hourMatch) {
     return Math.round(parseFloat(hourMatch[1]) * 60);
   }
-  
+
   // Handle minute formats: "120m", "120 minutes"
   const minuteMatch = input.match(/^(\d+)\s*m(?:inutes?)?$/);
   if (minuteMatch) {
     return parseInt(minuteMatch[1], 10);
   }
-  
+
   // Handle decimal hour formats: "2.5", "1.25"
   const decimalMatch = input.match(/^(\d*\.?\d+)$/);
   if (decimalMatch) {
     return Math.round(parseFloat(decimalMatch[1]) * 60);
   }
-  
-  throw new Error(`Invalid time format: ${timeInput}. Use formats like "2h", "120m", or "2.5"`);
+
+  throw new Error(
+    `Invalid time format: ${timeInput}. Use formats like "2h", "120m", or "2.5"`,
+  );
 }
 
 // Helper function to parse date input
 export function parseDate(dateInput: string): string {
   const input = dateInput.toLowerCase().trim();
   const today = new Date();
-  
-  if (input === 'today') {
-    return today.toISOString().split('T')[0];
+
+  if (input === "today") {
+    return today.toISOString().split("T")[0];
   }
-  
-  if (input === 'yesterday') {
+
+  if (input === "yesterday") {
     const yesterday = new Date(today);
     yesterday.setDate(yesterday.getDate() - 1);
-    return yesterday.toISOString().split('T')[0];
+    return yesterday.toISOString().split("T")[0];
   }
-  
+
   // Validate YYYY-MM-DD format
   const dateMatch = input.match(/^(\d{4})-(\d{2})-(\d{2})$/);
   if (dateMatch) {
     const year = parseInt(dateMatch[1], 10);
     const month = parseInt(dateMatch[2], 10);
     const day = parseInt(dateMatch[3], 10);
-    
+
     // Basic validation
     if (month < 1 || month > 12 || day < 1 || day > 31) {
       throw new Error(`Invalid date: ${dateInput}`);
     }
-    
+
     return input;
   }
-  
-  throw new Error(`Invalid date format: ${dateInput}. Use "today", "yesterday", or YYYY-MM-DD format`);
+
+  throw new Error(
+    `Invalid date format: ${dateInput}. Use "today", "yesterday", or YYYY-MM-DD format`,
+  );
 }
 
 const listTimeEntriesSchema = z.object({
@@ -83,46 +87,57 @@ const listTimeEntriesSchema = z.object({
 });
 
 const createTimeEntrySchema = z.object({
-  date: z.string().min(1, 'Date is required'),
-  time: z.string().min(1, 'Time is required'),
-  person_id: z.string().min(1, 'Person ID is required'),
-  service_id: z.string().min(1, 'Service ID is required'),
-  task_id: z.string().optional().describe('Optional task ID - use list_project_tasks to find available tasks for the project'),
-  note: z.string().min(10, 'Work description must be at least 10 characters').describe('REQUIRED: Detailed description of work performed - be specific about what was accomplished, including bullet points if multiple items'),
+  date: z.string().min(1, "Date is required"),
+  time: z.string().min(1, "Time is required"),
+  person_id: z.string().min(1, "Person ID is required"),
+  service_id: z.string().min(1, "Service ID is required"),
+  task_id: z
+    .string()
+    .optional()
+    .describe(
+      "Optional task ID - use list_project_tasks to find available tasks for the project",
+    ),
+  note: z
+    .string()
+    .min(10, "Work description must be at least 10 characters")
+    .describe(
+      "REQUIRED: Detailed description of work performed - be specific about what was accomplished, including bullet points if multiple items",
+    ),
   billable_time: z.string().optional(),
   confirm: z.boolean().optional().default(false),
 });
 
 const listServicesSchema = z.object({
   company_id: z.string().optional(),
+  budget_status: z.number().min(1).max(2).optional(),
   limit: z.number().min(1).max(200).default(30).optional(),
 });
 
 const getProjectServicesSchema = z.object({
-  project_id: z.string().min(1, 'Project ID is required'),
+  project_id: z.string().min(1, "Project ID is required"),
   limit: z.number().min(1).max(200).default(30).optional(),
 });
 
 export async function listTimeEntresTool(
   client: ProductiveAPIClient,
   args: unknown,
-  config?: { PRODUCTIVE_USER_ID?: string }
+  config?: { PRODUCTIVE_USER_ID?: string },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = listTimeEntriesSchema.parse(args);
-    
+
     // Handle "me" reference for person_id
     let personId = params.person_id;
-    if (personId === 'me') {
+    if (personId === "me") {
       if (!config?.PRODUCTIVE_USER_ID) {
         throw new McpError(
           ErrorCode.InvalidParams,
-          'Cannot use "me" reference - PRODUCTIVE_USER_ID is not configured in environment'
+          'Cannot use "me" reference - PRODUCTIVE_USER_ID is not configured in environment',
         );
       }
       personId = config.PRODUCTIVE_USER_ID;
     }
-    
+
     const response = await client.listTimeEntries({
       date: params.date,
       after: params.after,
@@ -133,61 +148,73 @@ export async function listTimeEntresTool(
       service_id: params.service_id,
       limit: params.limit,
     });
-    
+
     if (!response.data || response.data.length === 0) {
       return {
-        content: [{
-          type: 'text',
-          text: 'No time entries found matching the criteria.',
-        }],
+        content: [
+          {
+            type: "text",
+            text: "No time entries found matching the criteria.",
+          },
+        ],
       };
     }
-    
-    const entriesText = response.data.map(entry => {
-      const personId = entry.relationships?.person?.data?.id;
-      const serviceId = entry.relationships?.service?.data?.id;
-      const taskId = entry.relationships?.task?.data?.id;
-      const projectId = entry.relationships?.project?.data?.id;
-      
-      const timeDisplay = formatMinutesDisplay(entry.attributes.time);
 
-      let billableDisplay = '';
-      if (entry.attributes.billable_time !== undefined && entry.attributes.billable_time !== entry.attributes.time) {
-        billableDisplay = ` (Billable: ${formatMinutesDisplay(entry.attributes.billable_time)})`;
-      }
-      
-      return `• Time Entry (ID: ${entry.id})
+    const entriesText = response.data
+      .map((entry) => {
+        const personId = entry.relationships?.person?.data?.id;
+        const serviceId = entry.relationships?.service?.data?.id;
+        const taskId = entry.relationships?.task?.data?.id;
+        const projectId = entry.relationships?.project?.data?.id;
+
+        const timeDisplay = formatMinutesDisplay(entry.attributes.time);
+
+        let billableDisplay = "";
+        if (
+          entry.attributes.billable_time !== undefined &&
+          entry.attributes.billable_time !== entry.attributes.time
+        ) {
+          billableDisplay = ` (Billable: ${formatMinutesDisplay(entry.attributes.billable_time)})`;
+        }
+
+        return `• Time Entry (ID: ${entry.id})
   Date: ${entry.attributes.date}
   Time: ${timeDisplay}${billableDisplay}
-  Note: ${entry.attributes.note || 'No note'}
-  Person ID: ${personId || 'Unknown'}
-  Service ID: ${serviceId || 'Unknown'}
-  Task ID: ${taskId || 'None'}
-  Project ID: ${projectId || 'None'}`;
-    }).join('\n\n');
-    
-    const totalMinutes = response.data.reduce((sum, entry) => sum + entry.attributes.time, 0);
+  Note: ${entry.attributes.note || "No note"}
+  Person ID: ${personId || "Unknown"}
+  Service ID: ${serviceId || "Unknown"}
+  Task ID: ${taskId || "None"}
+  Project ID: ${projectId || "None"}`;
+      })
+      .join("\n\n");
+
+    const totalMinutes = response.data.reduce(
+      (sum, entry) => sum + entry.attributes.time,
+      0,
+    );
     const totalDisplay = formatMinutesDisplay(totalMinutes);
-    
-    const summary = `Found ${response.data.length} time entr${response.data.length !== 1 ? 'ies' : 'y'}${response.meta?.total_count ? ` (showing ${response.data.length} of ${response.meta.total_count})` : ''}:\n\nTotal Time: ${totalDisplay}\n\n${entriesText}`;
-    
+
+    const summary = `Found ${response.data.length} time entr${response.data.length !== 1 ? "ies" : "y"}${response.meta?.total_count ? ` (showing ${response.data.length} of ${response.meta.total_count})` : ""}:\n\nTotal Time: ${totalDisplay}\n\n${entriesText}`;
+
     return {
-      content: [{
-        type: 'text',
-        text: summary,
-      }],
+      content: [
+        {
+          type: "text",
+          text: summary,
+        },
+      ],
     };
   } catch (error) {
     if (error instanceof z.ZodError) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+        `Invalid parameters: ${error.errors.map((e) => e.message).join(", ")}`,
       );
     }
-    
+
     throw new McpError(
       ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
+      error instanceof Error ? error.message : "Unknown error occurred",
     );
   }
 }
@@ -195,23 +222,23 @@ export async function listTimeEntresTool(
 export async function createTimeEntryTool(
   client: ProductiveAPIClient,
   args: unknown,
-  config?: { PRODUCTIVE_USER_ID?: string }
+  config?: { PRODUCTIVE_USER_ID?: string },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = createTimeEntrySchema.parse(args);
-    
+
     // Handle "me" reference for person_id
     let personId = params.person_id;
-    if (personId === 'me') {
+    if (personId === "me") {
       if (!config?.PRODUCTIVE_USER_ID) {
         throw new McpError(
           ErrorCode.InvalidParams,
-          'Cannot use "me" reference - PRODUCTIVE_USER_ID is not configured in environment'
+          'Cannot use "me" reference - PRODUCTIVE_USER_ID is not configured in environment',
         );
       }
       personId = config.PRODUCTIVE_USER_ID;
     }
-    
+
     // Parse and validate date
     let parsedDate: string;
     try {
@@ -219,10 +246,10 @@ export async function createTimeEntryTool(
     } catch (error) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        error instanceof Error ? error.message : 'Invalid date format'
+        error instanceof Error ? error.message : "Invalid date format",
       );
     }
-    
+
     // Parse and validate time
     let timeInMinutes: number;
     try {
@@ -230,10 +257,10 @@ export async function createTimeEntryTool(
     } catch (error) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        error instanceof Error ? error.message : 'Invalid time format'
+        error instanceof Error ? error.message : "Invalid time format",
       );
     }
-    
+
     // Parse billable time if provided
     let billableTimeInMinutes: number | undefined;
     if (params.billable_time) {
@@ -242,274 +269,298 @@ export async function createTimeEntryTool(
       } catch (error) {
         throw new McpError(
           ErrorCode.InvalidParams,
-          `Invalid billable time format: ${error instanceof Error ? error.message : 'Invalid time format'}`
+          `Invalid billable time format: ${error instanceof Error ? error.message : "Invalid time format"}`,
         );
       }
     }
-    
+
     // If not confirmed, show confirmation details
     if (!params.confirm) {
       const timeDisplay = formatMinutesDisplay(timeInMinutes);
 
-      let billableDisplay = '';
+      let billableDisplay = "";
       if (billableTimeInMinutes !== undefined) {
         billableDisplay = `\nBillable Time: ${formatMinutesDisplay(billableTimeInMinutes)}`;
       }
-      
+
       return {
-        content: [{
-          type: 'text',
-          text: `Time Entry Ready to Create:
+        content: [
+          {
+            type: "text",
+            text: `Time Entry Ready to Create:
 
 Date: ${parsedDate}
 Time: ${timeDisplay}${billableDisplay}
-Person ID: ${personId}${params.person_id === 'me' ? ' (me)' : ''}
+Person ID: ${personId}${params.person_id === "me" ? " (me)" : ""}
 Service ID: ${params.service_id}
-${params.task_id ? `Task ID: ${params.task_id}` : 'No task specified'}
-${params.note ? `Note: ${params.note}` : 'No note'}
+${params.task_id ? `Task ID: ${params.task_id}` : "No task specified"}
+${params.note ? `Note: ${params.note}` : "No note"}
 
 To create this time entry, call this tool again with the same parameters and add "confirm": true`,
-        }],
+          },
+        ],
       };
     }
-    
+
     const timeEntryData: ProductiveTimeEntryCreate = {
       data: {
-        type: 'time_entries',
+        type: "time_entries",
         attributes: {
           date: parsedDate,
           time: timeInMinutes,
-          ...(billableTimeInMinutes !== undefined && { billable_time: billableTimeInMinutes }),
+          ...(billableTimeInMinutes !== undefined && {
+            billable_time: billableTimeInMinutes,
+          }),
           ...(params.note && { note: params.note }),
         },
         relationships: {
           person: {
             data: {
               id: personId,
-              type: 'people',
+              type: "people",
             },
           },
           service: {
             data: {
               id: params.service_id,
-              type: 'services',
+              type: "services",
             },
           },
         },
       },
     };
-    
+
     // Add task relationship if provided
     if (params.task_id) {
       timeEntryData.data.relationships.task = {
         data: {
           id: params.task_id,
-          type: 'tasks',
+          type: "tasks",
         },
       };
     }
-    
+
     const response = await client.createTimeEntry(timeEntryData);
-    
+
     const timeDisplay = formatMinutesDisplay(response.data.attributes.time);
 
-    let billableDisplay = '';
-    if (response.data.attributes.billable_time !== undefined && response.data.attributes.billable_time !== response.data.attributes.time) {
+    let billableDisplay = "";
+    if (
+      response.data.attributes.billable_time !== undefined &&
+      response.data.attributes.billable_time !== response.data.attributes.time
+    ) {
       billableDisplay = `\nBillable Time: ${formatMinutesDisplay(response.data.attributes.billable_time)}`;
     }
-    
+
     let text = `Time entry created successfully!
 Date: ${response.data.attributes.date}
 Time: ${timeDisplay}${billableDisplay}
 ID: ${response.data.id}`;
-    
+
     if (response.data.attributes.note) {
       text += `\nNote: ${response.data.attributes.note}`;
     }
-    
+
     text += `\nPerson ID: ${personId}`;
-    if (params.person_id === 'me' && config?.PRODUCTIVE_USER_ID) {
+    if (params.person_id === "me" && config?.PRODUCTIVE_USER_ID) {
       text += ` (me)`;
     }
-    
+
     text += `\nService ID: ${params.service_id}`;
-    
+
     if (params.task_id) {
       text += `\nTask ID: ${params.task_id}`;
     }
-    
+
     if (response.data.attributes.created_at) {
       text += `\nCreated at: ${response.data.attributes.created_at}`;
     }
-    
+
     return {
-      content: [{
-        type: 'text',
-        text: text,
-      }],
+      content: [
+        {
+          type: "text",
+          text: text,
+        },
+      ],
     };
   } catch (error) {
     if (error instanceof z.ZodError) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+        `Invalid parameters: ${error.errors.map((e) => e.message).join(", ")}`,
       );
     }
-    
+
     throw new McpError(
       ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
+      error instanceof Error ? error.message : "Unknown error occurred",
     );
   }
 }
 
 export async function listServicesTool(
   client: ProductiveAPIClient,
-  args: unknown
+  args: unknown,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = listServicesSchema.parse(args);
-    
+
     const response = await client.listServices({
       company_id: params.company_id,
+      budget_status: params.budget_status,
       limit: params.limit,
     });
-    
+
     if (!response.data || response.data.length === 0) {
       return {
-        content: [{
-          type: 'text',
-          text: 'No services found matching the criteria.',
-        }],
+        content: [
+          {
+            type: "text",
+            text: "No services found matching the criteria.",
+          },
+        ],
       };
     }
-    
-    const servicesText = response.data.map(service => {
-      const companyId = service.relationships?.company?.data?.id;
-      return `• ${service.attributes.name} (ID: ${service.id})
-  ${companyId ? `Company ID: ${companyId}` : ''}
-  ${service.attributes.description ? `Description: ${service.attributes.description}` : 'No description'}`;
-    }).join('\n\n');
-    
-    const summary = `Found ${response.data.length} service${response.data.length !== 1 ? 's' : ''}${response.meta?.total_count ? ` (showing ${response.data.length} of ${response.meta.total_count})` : ''}:\n\n${servicesText}`;
-    
+
+    const servicesText = response.data
+      .map((service) => {
+        const companyId = service.relationships?.company?.data?.id;
+        return `• ${service.attributes.name} (ID: ${service.id})
+  ${companyId ? `Company ID: ${companyId}` : ""}
+  ${service.attributes.description ? `Description: ${service.attributes.description}` : "No description"}`;
+      })
+      .join("\n\n");
+
+    const summary = `Found ${response.data.length} service${response.data.length !== 1 ? "s" : ""}${response.meta?.total_count ? ` (showing ${response.data.length} of ${response.meta.total_count})` : ""}:\n\n${servicesText}`;
+
     return {
-      content: [{
-        type: 'text',
-        text: summary,
-      }],
+      content: [
+        {
+          type: "text",
+          text: summary,
+        },
+      ],
     };
   } catch (error) {
     if (error instanceof z.ZodError) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+        `Invalid parameters: ${error.errors.map((e) => e.message).join(", ")}`,
       );
     }
-    
+
     throw new McpError(
       ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
+      error instanceof Error ? error.message : "Unknown error occurred",
     );
   }
 }
 
 export async function getProjectServicesTool(
   client: ProductiveAPIClient,
-  args: unknown
+  args: unknown,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = getProjectServicesSchema.parse(args);
-    
+
     // First get the project to verify it exists and get company info
     const projectResponse = await client.listProjects({
       limit: 1,
     });
-    
+
     // Then get services for the project's company
     // Note: This is a simplified approach - in practice you might need
     // to get the project details first to find its company
     const response = await client.listServices({
       limit: params.limit,
     });
-    
+
     if (!response.data || response.data.length === 0) {
       return {
-        content: [{
-          type: 'text',
-          text: `No active services found for project ${params.project_id}.`,
-        }],
+        content: [
+          {
+            type: "text",
+            text: `No active services found for project ${params.project_id}.`,
+          },
+        ],
       };
     }
-    
-    const servicesText = response.data.map(service => {
-      const companyId = service.relationships?.company?.data?.id;
-      
-      return `• ${service.attributes.name} (ID: ${service.id})
-  ${companyId ? `Company ID: ${companyId}` : ''}
-  ${service.attributes.description ? `Description: ${service.attributes.description}` : 'No description'}`;
-    }).join('\n\n');
-    
-    const summary = `Services available for project ${params.project_id} (${response.data.length} service${response.data.length !== 1 ? 's' : ''}):\n\n${servicesText}`;
-    
+
+    const servicesText = response.data
+      .map((service) => {
+        const companyId = service.relationships?.company?.data?.id;
+
+        return `• ${service.attributes.name} (ID: ${service.id})
+  ${companyId ? `Company ID: ${companyId}` : ""}
+  ${service.attributes.description ? `Description: ${service.attributes.description}` : "No description"}`;
+      })
+      .join("\n\n");
+
+    const summary = `Services available for project ${params.project_id} (${response.data.length} service${response.data.length !== 1 ? "s" : ""}):\n\n${servicesText}`;
+
     return {
-      content: [{
-        type: 'text',
-        text: summary,
-      }],
+      content: [
+        {
+          type: "text",
+          text: summary,
+        },
+      ],
     };
   } catch (error) {
     if (error instanceof z.ZodError) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+        `Invalid parameters: ${error.errors.map((e) => e.message).join(", ")}`,
       );
     }
-    
+
     throw new McpError(
       ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
+      error instanceof Error ? error.message : "Unknown error occurred",
     );
   }
 }
 
 export const listTimeEntriesDefinition = {
-  name: 'list_time_entries',
-  description: 'View existing time entries from Productive.io with detailed information including service and budget relationships. Use this to see what time has been logged and to which projects/services. If PRODUCTIVE_USER_ID is configured, you can use "me" to refer to the configured user for person_id.',
+  name: "list_time_entries",
+  description:
+    'View existing time entries from Productive.io with detailed information including service and budget relationships. Use this to see what time has been logged and to which projects/services. If PRODUCTIVE_USER_ID is configured, you can use "me" to refer to the configured user for person_id.',
   inputSchema: {
-    type: 'object',
+    type: "object",
     properties: {
       date: {
-        type: 'string',
-        description: 'Filter by specific date (YYYY-MM-DD format)',
+        type: "string",
+        description: "Filter by specific date (YYYY-MM-DD format)",
       },
       after: {
-        type: 'string',
-        description: 'Filter entries after this date (YYYY-MM-DD format)',
+        type: "string",
+        description: "Filter entries after this date (YYYY-MM-DD format)",
       },
       before: {
-        type: 'string',
-        description: 'Filter entries before this date (YYYY-MM-DD format)',
+        type: "string",
+        description: "Filter entries before this date (YYYY-MM-DD format)",
       },
       person_id: {
-        type: 'string',
-        description: 'Filter by person ID. If PRODUCTIVE_USER_ID is configured in environment, "me" refers to that user.',
+        type: "string",
+        description:
+          'Filter by person ID. If PRODUCTIVE_USER_ID is configured in environment, "me" refers to that user.',
       },
       project_id: {
-        type: 'string',
-        description: 'Filter by project ID',
+        type: "string",
+        description: "Filter by project ID",
       },
       task_id: {
-        type: 'string',
-        description: 'Filter by task ID',
+        type: "string",
+        description: "Filter by task ID",
       },
       service_id: {
-        type: 'string',
-        description: 'Filter by service ID',
+        type: "string",
+        description: "Filter by service ID",
       },
       limit: {
-        type: 'number',
-        description: 'Number of time entries to return (1-200)',
+        type: "number",
+        description: "Number of time entries to return (1-200)",
         minimum: 1,
         maximum: 200,
         default: 30,
@@ -520,63 +571,78 @@ export const listTimeEntriesDefinition = {
 };
 
 export const createTimeEntryDefinition = {
-  name: 'create_time_entry',
-  description: 'STEP 5 (FINAL) of timesheet workflow: Create a time entry with detailed work description. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) list_project_tasks (recommended) → 5) create_time_entry. You MUST provide: valid service_id from the hierarchy, detailed work notes (minimum 10 chars), and optionally link to a specific task_id. This tool requires confirmation before creating. If PRODUCTIVE_USER_ID is configured, use "me" for person_id.',
+  name: "create_time_entry",
+  description:
+    'STEP 5 (FINAL) of timesheet workflow: Create a time entry with detailed work description. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) list_project_tasks (recommended) → 5) create_time_entry. You MUST provide: valid service_id from the hierarchy, detailed work notes (minimum 10 chars), and optionally link to a specific task_id. This tool requires confirmation before creating. If PRODUCTIVE_USER_ID is configured, use "me" for person_id.',
   inputSchema: {
-    type: 'object',
+    type: "object",
     properties: {
       date: {
-        type: 'string',
-        description: 'Date for the time entry. Accepts "today", "yesterday", or YYYY-MM-DD format (required)',
+        type: "string",
+        description:
+          'Date for the time entry. Accepts "today", "yesterday", or YYYY-MM-DD format (required)',
       },
       time: {
-        type: 'string',
-        description: 'Time duration. Accepts formats like "2h", "120m", "2.5h", or "2.5" (assumed hours) (required)',
+        type: "string",
+        description:
+          'Time duration. Accepts formats like "2h", "120m", "2.5h", or "2.5" (assumed hours) (required)',
       },
       person_id: {
-        type: 'string',
-        description: 'ID of the person logging time. If PRODUCTIVE_USER_ID is configured in environment, "me" refers to that user. (required)',
+        type: "string",
+        description:
+          'ID of the person logging time. If PRODUCTIVE_USER_ID is configured in environment, "me" refers to that user. (required)',
       },
       service_id: {
-        type: 'string',
-        description: 'ID of the service being performed (required)',
+        type: "string",
+        description: "ID of the service being performed (required)",
       },
       task_id: {
-        type: 'string',
-        description: 'ID of the task being worked on (recommended - use list_project_tasks to find available tasks)',
+        type: "string",
+        description:
+          "ID of the task being worked on (recommended - use list_project_tasks to find available tasks)",
       },
       note: {
-        type: 'string',
-        description: 'REQUIRED: Detailed description of work performed - be specific about what was accomplished, include bullet points if multiple items (minimum 10 characters)',
+        type: "string",
+        description:
+          "REQUIRED: Detailed description of work performed - be specific about what was accomplished, include bullet points if multiple items (minimum 10 characters)",
         minLength: 10,
       },
       billable_time: {
-        type: 'string',
-        description: 'Billable time duration, same format as time field. If not specified, defaults to the time value (optional)',
+        type: "string",
+        description:
+          "Billable time duration, same format as time field. If not specified, defaults to the time value (optional)",
       },
       confirm: {
-        type: 'boolean',
-        description: 'Set to true to confirm and create the time entry. First call without this to see confirmation details.',
+        type: "boolean",
+        description:
+          "Set to true to confirm and create the time entry. First call without this to see confirmation details.",
         default: false,
       },
     },
-    required: ['date', 'time', 'person_id', 'service_id', 'note'],
+    required: ["date", "time", "person_id", "service_id", "note"],
   },
 };
 
 export const listServicesDefinition = {
-  name: 'list_services',
-  description: 'List all services in the organization. NOTE: For timesheet entries, use the proper workflow instead: list_projects → list_project_deals → list_deal_services → create_time_entry. This tool shows all services but does not indicate which project/budget they belong to.',
+  name: "list_services",
+  description:
+    "List services in the organization. NOTE: For timesheet entries, use the proper workflow instead: list_projects → list_project_deals → list_deal_services → create_time_entry. For timers, use this tool directly with budget_status=1 to find services with open budgets, then pass the service_id to start_timer.",
   inputSchema: {
-    type: 'object',
+    type: "object",
     properties: {
       company_id: {
-        type: 'string',
-        description: 'Filter services by company ID',
+        type: "string",
+        description: "Filter services by company ID",
+      },
+      budget_status: {
+        type: "number",
+        description: "Filter by budget status: 1 = open, 2 = delivered",
+        minimum: 1,
+        maximum: 2,
       },
       limit: {
-        type: 'number',
-        description: 'Number of services to return (1-200)',
+        type: "number",
+        description: "Number of services to return (1-200)",
         minimum: 1,
         maximum: 200,
         default: 30,
@@ -588,194 +654,225 @@ export const listServicesDefinition = {
 
 // Zod schema for list project deals/budgets
 const listProjectDealsSchema = z.object({
-  project_id: z.string().min(1, 'Project ID is required'),
-  budget_type: z.number().int().min(1).max(2).optional().describe('Budget type: 1 = deal, 2 = budget'),
+  project_id: z.string().min(1, "Project ID is required"),
+  budget_type: z
+    .number()
+    .int()
+    .min(1)
+    .max(2)
+    .optional()
+    .describe("Budget type: 1 = deal, 2 = budget"),
   limit: z.number().min(1).max(200).default(30).optional(),
 });
 
 // Tool function for list project deals/budgets
 export async function listProjectDealsTool(
   client: ProductiveAPIClient,
-  args: unknown
+  args: unknown,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = listProjectDealsSchema.parse(args);
-    
+
     const response = await client.listProjectDeals({
       project_id: params.project_id,
       budget_type: params.budget_type,
       limit: params.limit,
     });
-    
+
     if (!response.data || response.data.length === 0) {
       return {
-        content: [{
-          type: 'text',
-          text: 'No deals/budgets found for this project.',
-        }],
+        content: [
+          {
+            type: "text",
+            text: "No deals/budgets found for this project.",
+          },
+        ],
       };
     }
-    
-    const dealsText = response.data.map(deal => {
-      const budgetType = deal.attributes.budget_type === 1 ? 'Deal' : 
-                        deal.attributes.budget_type === 2 ? 'Budget' : 'Unknown';
-      const value = deal.attributes.value ? ` (Value: ${deal.attributes.value})` : '';
-      
-      return `• ${budgetType} (ID: ${deal.id})
+
+    const dealsText = response.data
+      .map((deal) => {
+        const budgetType =
+          deal.attributes.budget_type === 1
+            ? "Deal"
+            : deal.attributes.budget_type === 2
+              ? "Budget"
+              : "Unknown";
+        const value = deal.attributes.value
+          ? ` (Value: ${deal.attributes.value})`
+          : "";
+
+        return `• ${budgetType} (ID: ${deal.id})
   Name: ${deal.attributes.name}${value}`;
-    }).join('\n\n');
-    
-    const typeFilter = params.budget_type === 1 ? ' deals' : 
-                      params.budget_type === 2 ? ' budgets' : ' deals/budgets';
-    
+      })
+      .join("\n\n");
+
+    const typeFilter =
+      params.budget_type === 1
+        ? " deals"
+        : params.budget_type === 2
+          ? " budgets"
+          : " deals/budgets";
+
     const summary = `Found ${response.data.length}${typeFilter} for project ${params.project_id}:\n\n${dealsText}`;
-    
+
     return {
-      content: [{
-        type: 'text',
-        text: summary,
-      }],
+      content: [
+        {
+          type: "text",
+          text: summary,
+        },
+      ],
     };
   } catch (error) {
     if (error instanceof z.ZodError) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+        `Invalid parameters: ${error.errors.map((e) => e.message).join(", ")}`,
       );
     }
-    
+
     throw new McpError(
       ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
+      error instanceof Error ? error.message : "Unknown error occurred",
     );
   }
 }
 
 // Zod schema for list deal services
 const listDealServicesSchema = z.object({
-  deal_id: z.string().min(1, 'Deal/Budget ID is required'),
+  deal_id: z.string().min(1, "Deal/Budget ID is required"),
   limit: z.number().min(1).max(200).default(30).optional(),
 });
 
 // Tool function for list deal services
 export async function listDealServicesTool(
   client: ProductiveAPIClient,
-  args: unknown
+  args: unknown,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = listDealServicesSchema.parse(args);
-    
+
     const response = await client.listDealServices({
       deal_id: params.deal_id,
       limit: params.limit,
     });
-    
+
     if (!response.data || response.data.length === 0) {
       return {
-        content: [{
-          type: 'text',
-          text: 'No services found for this deal/budget.',
-        }],
+        content: [
+          {
+            type: "text",
+            text: "No services found for this deal/budget.",
+          },
+        ],
       };
     }
-    
-    const servicesText = response.data.map(service => {
-      return `• Service (ID: ${service.id})
-  Name: ${service.attributes.name || 'Unnamed Service'}
-  ${service.attributes.description ? `Description: ${service.attributes.description}` : 'No description'}`;
-    }).join('\n\n');
-    
-    const summary = `Found ${response.data.length} service${response.data.length !== 1 ? 's' : ''} for deal/budget ${params.deal_id}:\n\n${servicesText}`;
-    
+
+    const servicesText = response.data
+      .map((service) => {
+        return `• Service (ID: ${service.id})
+  Name: ${service.attributes.name || "Unnamed Service"}
+  ${service.attributes.description ? `Description: ${service.attributes.description}` : "No description"}`;
+      })
+      .join("\n\n");
+
+    const summary = `Found ${response.data.length} service${response.data.length !== 1 ? "s" : ""} for deal/budget ${params.deal_id}:\n\n${servicesText}`;
+
     return {
-      content: [{
-        type: 'text',
-        text: summary,
-      }],
+      content: [
+        {
+          type: "text",
+          text: summary,
+        },
+      ],
     };
   } catch (error) {
     if (error instanceof z.ZodError) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+        `Invalid parameters: ${error.errors.map((e) => e.message).join(", ")}`,
       );
     }
-    
+
     throw new McpError(
       ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
+      error instanceof Error ? error.message : "Unknown error occurred",
     );
   }
 }
 
 export const listProjectDealsDefinition = {
-  name: 'list_project_deals',
-  description: 'STEP 2 of timesheet workflow: Get deals/budgets for a specific project. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) list_project_tasks (recommended) → 5) create_time_entry. This follows: Project → Deal/Budget → Service → Task → Time Entry.',
+  name: "list_project_deals",
+  description:
+    "STEP 2 of timesheet workflow: Get deals/budgets for a specific project. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) list_project_tasks (recommended) → 5) create_time_entry. This follows: Project → Deal/Budget → Service → Task → Time Entry.",
   inputSchema: {
-    type: 'object',
+    type: "object",
     properties: {
       project_id: {
-        type: 'string',
-        description: 'The ID of the project (required)',
+        type: "string",
+        description: "The ID of the project (required)",
       },
       budget_type: {
-        type: 'number',
-        description: 'Filter by budget type: 1 = deal, 2 = budget',
+        type: "number",
+        description: "Filter by budget type: 1 = deal, 2 = budget",
         minimum: 1,
         maximum: 2,
       },
       limit: {
-        type: 'number',
-        description: 'Number of deals/budgets to return (1-200)',
+        type: "number",
+        description: "Number of deals/budgets to return (1-200)",
         minimum: 1,
         maximum: 200,
         default: 30,
       },
     },
-    required: ['project_id'],
+    required: ["project_id"],
   },
 };
 
 export const listDealServicesDefinition = {
-  name: 'list_deal_services',
-  description: 'STEP 3 of timesheet workflow: Get services for a specific deal/budget. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) list_project_tasks (recommended) → 5) create_time_entry. After this, optionally use list_project_tasks to find specific tasks to link your time entry to.',
+  name: "list_deal_services",
+  description:
+    "STEP 3 of timesheet workflow: Get services for a specific deal/budget. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) list_project_tasks (recommended) → 5) create_time_entry. After this, optionally use list_project_tasks to find specific tasks to link your time entry to.",
   inputSchema: {
-    type: 'object',
+    type: "object",
     properties: {
       deal_id: {
-        type: 'string',
-        description: 'The ID of the deal/budget (required)',
+        type: "string",
+        description: "The ID of the deal/budget (required)",
       },
       limit: {
-        type: 'number',
-        description: 'Number of services to return (1-200)',
+        type: "number",
+        description: "Number of services to return (1-200)",
         minimum: 1,
         maximum: 200,
         default: 30,
       },
     },
-    required: ['deal_id'],
+    required: ["deal_id"],
   },
 };
 
 export const getProjectServicesDefinition = {
-  name: 'get_project_services',
-  description: 'DEPRECATED: Use the proper workflow instead: list_projects → list_project_deals → list_deal_services → create_time_entry. This tool does not properly handle the project → deal/budget → service hierarchy required for timesheet entries.',
+  name: "get_project_services",
+  description:
+    "DEPRECATED: Use the proper workflow instead: list_projects → list_project_deals → list_deal_services → create_time_entry. This tool does not properly handle the project → deal/budget → service hierarchy required for timesheet entries.",
   inputSchema: {
-    type: 'object',
+    type: "object",
     properties: {
       project_id: {
-        type: 'string',
-        description: 'The ID of the project',
+        type: "string",
+        description: "The ID of the project",
       },
       limit: {
-        type: 'number',
-        description: 'Number of services to return (1-200)',
+        type: "number",
+        description: "Number of services to return (1-200)",
         minimum: 1,
         maximum: 200,
         default: 30,
       },
     },
-    required: ['project_id'],
+    required: ["project_id"],
   },
 };

--- a/src/tools/time-entry-approval.ts
+++ b/src/tools/time-entry-approval.ts
@@ -1,0 +1,192 @@
+import { z } from 'zod';
+import { ProductiveAPIClient } from '../api/client.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ProductiveTimeEntry } from '../api/types.js';
+import { formatMinutesDisplay } from './time-entries.js';
+
+const timeEntryIdSchema = z.object({
+  time_entry_id: z.string().min(1, 'Time entry ID is required'),
+});
+
+const rejectTimeEntrySchema = z.object({
+  time_entry_id: z.string().min(1, 'Time entry ID is required'),
+  rejected_reason: z.string().optional(),
+});
+
+function formatTimeEntryResponse(action: string, entry: ProductiveTimeEntry, extra?: string): { content: Array<{ type: string; text: string }> } {
+  let text = `Time entry ${action}!\n`;
+  text += `ID: ${entry.id}\n`;
+  text += `Date: ${entry.attributes.date}\n`;
+  text += `Time: ${formatMinutesDisplay(entry.attributes.time)}`;
+
+  if (extra) {
+    text += `\n${extra}`;
+  }
+
+  if (entry.attributes.note) {
+    text += `\nNote: ${entry.attributes.note}`;
+  }
+
+  if (entry.attributes.updated_at) {
+    text += `\nUpdated at: ${entry.attributes.updated_at}`;
+  }
+
+  return { content: [{ type: 'text', text }] };
+}
+
+export async function approveTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = timeEntryIdSchema.parse(args);
+    const response = await client.approveTimeEntry(params.time_entry_id);
+    return formatTimeEntryResponse('approved successfully', response.data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export async function unapproveTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = timeEntryIdSchema.parse(args);
+    const response = await client.unapproveTimeEntry(params.time_entry_id);
+    return formatTimeEntryResponse('unapproved successfully', response.data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export async function rejectTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = rejectTimeEntrySchema.parse(args);
+    const response = await client.rejectTimeEntry(params.time_entry_id, params.rejected_reason);
+    const extra = params.rejected_reason ? `Reason: ${params.rejected_reason}` : undefined;
+    return formatTimeEntryResponse('rejected', response.data, extra);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export async function unrejectTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = timeEntryIdSchema.parse(args);
+    const response = await client.unrejectTimeEntry(params.time_entry_id);
+    return formatTimeEntryResponse('unrejected successfully', response.data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export const approveTimeEntryDefinition = {
+  name: 'approve_time_entry',
+  description: 'Approve a time entry in Productive.io. Use list_time_entries to find the time entry ID first.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'ID of the time entry to approve (required)',
+      },
+    },
+    required: ['time_entry_id'],
+  },
+};
+
+export const unapproveTimeEntryDefinition = {
+  name: 'unapprove_time_entry',
+  description: 'Unapprove (reverse approval of) a time entry in Productive.io. Use list_time_entries to find the time entry ID first.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'ID of the time entry to unapprove (required)',
+      },
+    },
+    required: ['time_entry_id'],
+  },
+};
+
+export const rejectTimeEntryDefinition = {
+  name: 'reject_time_entry',
+  description: 'Reject a time entry in Productive.io with an optional reason. Use list_time_entries to find the time entry ID first.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'ID of the time entry to reject (required)',
+      },
+      rejected_reason: {
+        type: 'string',
+        description: 'Reason for rejecting the time entry (optional)',
+      },
+    },
+    required: ['time_entry_id'],
+  },
+};
+
+export const unrejectTimeEntryDefinition = {
+  name: 'unreject_time_entry',
+  description: 'Unreject (reverse rejection of) a time entry in Productive.io. Use list_time_entries to find the time entry ID first.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'ID of the time entry to unreject (required)',
+      },
+    },
+    required: ['time_entry_id'],
+  },
+};

--- a/src/tools/time-entry-update.ts
+++ b/src/tools/time-entry-update.ts
@@ -1,0 +1,147 @@
+import { z } from 'zod';
+import { ProductiveAPIClient } from '../api/client.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ProductiveTimeEntryUpdate } from '../api/types.js';
+import { parseTimeToMinutes, parseDate, formatMinutesDisplay } from './time-entries.js';
+
+const updateTimeEntrySchema = z.object({
+  time_entry_id: z.string().min(1, 'Time entry ID is required'),
+  date: z.string().optional(),
+  time: z.string().optional(),
+  billable_time: z.string().optional(),
+  note: z.string().optional(),
+});
+
+export async function updateTimeEntryTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = updateTimeEntrySchema.parse(args);
+
+    const attributes: Record<string, string | number> = {};
+
+    if (params.date !== undefined) {
+      try {
+        attributes.date = parseDate(params.date);
+      } catch (error) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          error instanceof Error ? error.message : 'Invalid date format'
+        );
+      }
+    }
+
+    if (params.time !== undefined) {
+      try {
+        attributes.time = parseTimeToMinutes(params.time);
+      } catch (error) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          error instanceof Error ? error.message : 'Invalid time format'
+        );
+      }
+    }
+
+    if (params.billable_time !== undefined) {
+      try {
+        attributes.billable_time = parseTimeToMinutes(params.billable_time);
+      } catch (error) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Invalid billable time format: ${error instanceof Error ? error.message : 'Invalid time format'}`
+        );
+      }
+    }
+
+    if (params.note !== undefined) {
+      attributes.note = params.note;
+    }
+
+    if (Object.keys(attributes).length === 0) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'At least one field to update must be provided (date, time, billable_time, or note)'
+      );
+    }
+
+    const updateData: ProductiveTimeEntryUpdate = {
+      data: {
+        type: 'time_entries',
+        id: params.time_entry_id,
+        attributes,
+      },
+    };
+
+    const response = await client.updateTimeEntry(params.time_entry_id, updateData);
+
+    const entry = response.data;
+    let text = `Time entry updated successfully!\n`;
+    text += `ID: ${entry.id}\n`;
+    text += `Date: ${entry.attributes.date}\n`;
+    text += `Time: ${formatMinutesDisplay(entry.attributes.time)}`;
+
+    if (entry.attributes.billable_time !== undefined && entry.attributes.billable_time !== entry.attributes.time) {
+      text += ` (Billable: ${formatMinutesDisplay(entry.attributes.billable_time)})`;
+    }
+
+    if (entry.attributes.note) {
+      text += `\nNote: ${entry.attributes.note}`;
+    }
+
+    if (entry.attributes.updated_at) {
+      text += `\nUpdated at: ${entry.attributes.updated_at}`;
+    }
+
+    return {
+      content: [{ type: 'text', text }],
+    };
+  } catch (error) {
+    if (error instanceof McpError) {
+      throw error;
+    }
+
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export const updateTimeEntryDefinition = {
+  name: 'update_time_entry',
+  description: 'Update an existing time entry in Productive.io. All fields except time_entry_id are optional - only provided fields will be updated. Use list_time_entries to find the time entry ID first.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      time_entry_id: {
+        type: 'string',
+        description: 'ID of the time entry to update (required)',
+      },
+      date: {
+        type: 'string',
+        description: 'New date. Accepts "today", "yesterday", or YYYY-MM-DD format',
+      },
+      time: {
+        type: 'string',
+        description: 'New time duration. Accepts formats like "2h", "120m", "2.5h", or "2.5" (assumed hours)',
+      },
+      billable_time: {
+        type: 'string',
+        description: 'New billable time duration. Same formats as time field',
+      },
+      note: {
+        type: 'string',
+        description: 'Updated work description',
+      },
+    },
+    required: ['time_entry_id'],
+  },
+};

--- a/src/tools/timers.ts
+++ b/src/tools/timers.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
 import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { ProductiveTimer, ProductiveTimerCreate } from '../api/types.js';
+import {
+  ProductiveTimer,
+  ProductiveTimerCreate,
+  ProductiveTimeEntryUpdate,
+} from '../api/types.js';
 import { formatMinutesDisplay } from './time-entries.js';
 
 const getTimerSchema = z.object({
@@ -9,18 +13,20 @@ const getTimerSchema = z.object({
 });
 
 const startTimerSchema = z.object({
+  service_name: z.string().optional(),
   service_id: z.string().optional(),
   time_entry_id: z.string().optional(),
-}).refine(
-  (data) => data.service_id || data.time_entry_id,
-  { message: 'Either service_id or time_entry_id must be provided' }
-);
+  note: z.string().min(5, 'Work description must be at least 5 characters'),
+});
 
 const stopTimerSchema = z.object({
   timer_id: z.string().min(1, 'Timer ID is required'),
 });
 
-function formatTimerResponse(action: string, timer: ProductiveTimer): { content: Array<{ type: string; text: string }> } {
+function formatTimerResponse(
+  action: string,
+  timer: ProductiveTimer,
+): { content: Array<{ type: string; text: string }> } {
   const isRunning = timer.attributes.stopped_at === null;
   let text = `Timer ${action}!\n`;
   text += `ID: ${timer.id}\n`;
@@ -43,35 +49,115 @@ function formatTimerResponse(action: string, timer: ProductiveTimer): { content:
   return { content: [{ type: 'text', text }] };
 }
 
+function matchServices(
+  services: Array<{ id: string; attributes: { name: string; [key: string]: unknown } }>,
+  searchName: string,
+): Array<{ id: string; attributes: { name: string; [key: string]: unknown } }> {
+  const lower = searchName.toLowerCase();
+
+  // Exact match first
+  const exact = services.filter(s => s.attributes.name.toLowerCase() === lower);
+  if (exact.length > 0) return exact;
+
+  // Contains match
+  const contains = services.filter(s => s.attributes.name.toLowerCase().includes(lower));
+  if (contains.length > 0) return contains;
+
+  // Word-based match: check if any word from the search appears in the service name
+  const searchWords = lower.split(/\s+/);
+  const wordMatch = services.filter(s => {
+    const name = s.attributes.name.toLowerCase();
+    return searchWords.some(word => word.length > 2 && name.includes(word));
+  });
+  return wordMatch;
+}
+
+function formatServicesList(
+  services: Array<{ id: string; attributes: { name: string; [key: string]: unknown } }>,
+): string {
+  return services.map(s => `• ${s.attributes.name} (ID: ${s.id})`).join('\n');
+}
+
 export async function getTimerTool(
   client: ProductiveAPIClient,
-  args: unknown
+  args: unknown,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = getTimerSchema.parse(args);
     const response = await client.getTimer(params.timer_id);
     return formatTimerResponse('found', response.data);
   } catch (error) {
+    if (error instanceof McpError) {
+      throw error;
+    }
+
     if (error instanceof z.ZodError) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`,
       );
     }
 
     throw new McpError(
       ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
+      error instanceof Error ? error.message : 'Unknown error occurred',
     );
   }
 }
 
 export async function startTimerTool(
   client: ProductiveAPIClient,
-  args: unknown
+  args: unknown,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = startTimerSchema.parse(args);
+
+    let resolvedServiceId = params.service_id;
+
+    // If no service_id and no time_entry_id, resolve via service_name or show list
+    if (!resolvedServiceId && !params.time_entry_id) {
+      const services = await client.listServices({ budget_status: 1, limit: 200 });
+
+      if (!services.data || services.data.length === 0) {
+        return {
+          content: [{ type: 'text', text: 'No services with open budgets found.' }],
+        };
+      }
+
+      // If service_name provided, try to match
+      if (params.service_name) {
+        const matches = matchServices(services.data, params.service_name);
+
+        if (matches.length === 1) {
+          // Single match — use it
+          resolvedServiceId = matches[0].id;
+        } else if (matches.length > 1) {
+          // Multiple matches — ask user to choose
+          return {
+            content: [{
+              type: 'text',
+              text: `Multiple services match "${params.service_name}". Please choose one and call start_timer again with the service_id:\n\n${formatServicesList(matches)}`,
+            }],
+          };
+        } else {
+          // No match — show all
+          return {
+            content: [{
+              type: 'text',
+              text: `No service found matching "${params.service_name}". Available services (open budgets):\n\n${formatServicesList(services.data)}\n\nPlease call start_timer again with the correct service_id.`,
+            }],
+          };
+        }
+      } else {
+        // No service_name, no service_id, no time_entry_id — show all
+        return {
+          content: [{
+            type: 'text',
+            text: `Please specify a service. Available services (open budgets):\n\n${formatServicesList(services.data)}\n\nCall start_timer again with service_name or service_id.`,
+          }],
+        };
+      }
+    }
 
     const timerData: ProductiveTimerCreate = {
       data: {
@@ -85,55 +171,93 @@ export async function startTimerTool(
       timerData.data.relationships.time_entry = {
         data: { id: params.time_entry_id, type: 'time_entries' },
       };
-    } else if (params.service_id) {
+    } else if (resolvedServiceId) {
       timerData.data.relationships.service = {
-        data: { id: params.service_id, type: 'services' },
+        data: { id: resolvedServiceId, type: 'services' },
       };
     }
 
     const response = await client.createTimer(timerData);
-    return formatTimerResponse('started', response.data);
+
+    // Resolve the time entry ID to set the note
+    let timeEntryId = params.time_entry_id;
+    if (!timeEntryId) {
+      const timerDetail = await client.getTimerWithTimeEntry(response.data.id);
+      timeEntryId = timerDetail.data.relationships?.time_entry?.data?.id;
+    }
+
+    let noteWarning = '';
+    if (timeEntryId) {
+      try {
+        const updateData: ProductiveTimeEntryUpdate = {
+          data: {
+            type: 'time_entries',
+            id: timeEntryId,
+            attributes: { note: params.note },
+          },
+        };
+        await client.updateTimeEntry(timeEntryId, updateData);
+      } catch {
+        noteWarning = '\nWarning: Timer started but note could not be set on the time entry.';
+      }
+    } else {
+      noteWarning = '\nWarning: Could not resolve time entry ID — note was not set.';
+    }
+
+    const result = formatTimerResponse('started', response.data);
+    if (noteWarning) {
+      result.content[0].text += noteWarning;
+    }
+    return result;
   } catch (error) {
+    if (error instanceof McpError) {
+      throw error;
+    }
+
     if (error instanceof z.ZodError) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`,
       );
     }
 
     throw new McpError(
       ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
+      error instanceof Error ? error.message : 'Unknown error occurred',
     );
   }
 }
 
 export async function stopTimerTool(
   client: ProductiveAPIClient,
-  args: unknown
+  args: unknown,
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = stopTimerSchema.parse(args);
     const response = await client.stopTimer(params.timer_id);
     return formatTimerResponse('stopped', response.data);
   } catch (error) {
+    if (error instanceof McpError) {
+      throw error;
+    }
+
     if (error instanceof z.ZodError) {
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`,
       );
     }
 
     throw new McpError(
       ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
+      error instanceof Error ? error.message : 'Unknown error occurred',
     );
   }
 }
 
 export const getTimerDefinition = {
   name: 'get_timer',
-  description: 'Get a timer by ID to check its status (running or stopped). Use this to verify if a timer is still running.',
+  description: 'Get a timer by ID to check its status (running or stopped).',
   inputSchema: {
     type: 'object',
     properties: {
@@ -148,19 +272,29 @@ export const getTimerDefinition = {
 
 export const startTimerDefinition = {
   name: 'start_timer',
-  description: 'Start a new timer for time tracking. Provide a valid service_id (use list_services to find available services) or a time_entry_id to attach to an existing time entry. The service_id creates a new time entry automatically.',
+  description: 'Start a new timer for time tracking. IMPORTANT: Do NOT guess service names or IDs. If the user does not explicitly name a service from Productive.io, call this tool WITHOUT service_name or service_id to get the list of available services, then present the list to the user and let them choose. Only use service_name if the user explicitly mentioned a specific service name. A work description (note) is always required.',
   inputSchema: {
     type: 'object',
     properties: {
+      service_name: {
+        type: 'string',
+        description: 'Name (or part of name) of the service to track time against. The tool will fuzzy-match against available services with open budgets.',
+      },
       service_id: {
         type: 'string',
-        description: 'Service ID to track time against (creates new time entry). Required if time_entry_id not provided.',
+        description: 'Direct service ID (optional, use service_name instead if you do not know the ID).',
       },
       time_entry_id: {
         type: 'string',
-        description: 'Existing time entry ID to attach timer to. Required if service_id not provided.',
+        description: 'Existing time entry ID to attach timer to (optional).',
+      },
+      note: {
+        type: 'string',
+        description: 'REQUIRED: Description of work being performed (minimum 5 characters).',
+        minLength: 5,
       },
     },
+    required: ['note'],
   },
 };
 

--- a/src/tools/timers.ts
+++ b/src/tools/timers.ts
@@ -1,0 +1,180 @@
+import { z } from 'zod';
+import { ProductiveAPIClient } from '../api/client.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ProductiveTimer, ProductiveTimerCreate } from '../api/types.js';
+import { formatMinutesDisplay } from './time-entries.js';
+
+const getTimerSchema = z.object({
+  timer_id: z.string().min(1, 'Timer ID is required'),
+});
+
+const startTimerSchema = z.object({
+  service_id: z.string().optional(),
+  time_entry_id: z.string().optional(),
+}).refine(
+  (data) => data.service_id || data.time_entry_id,
+  { message: 'Either service_id or time_entry_id must be provided' }
+);
+
+const stopTimerSchema = z.object({
+  timer_id: z.string().min(1, 'Timer ID is required'),
+});
+
+function formatTimerResponse(action: string, timer: ProductiveTimer): { content: Array<{ type: string; text: string }> } {
+  const isRunning = timer.attributes.stopped_at === null;
+  let text = `Timer ${action}!\n`;
+  text += `ID: ${timer.id}\n`;
+  text += `Status: ${isRunning ? 'Running' : 'Stopped'}\n`;
+  text += `Started at: ${timer.attributes.started_at}`;
+
+  if (timer.attributes.stopped_at) {
+    text += `\nStopped at: ${timer.attributes.stopped_at}`;
+  }
+
+  if (timer.attributes.total_time > 0) {
+    text += `\nTotal time: ${formatMinutesDisplay(timer.attributes.total_time)}`;
+  }
+
+  const timeEntryId = timer.relationships?.time_entry?.data?.id;
+  if (timeEntryId) {
+    text += `\nTime Entry ID: ${timeEntryId}`;
+  }
+
+  return { content: [{ type: 'text', text }] };
+}
+
+export async function getTimerTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = getTimerSchema.parse(args);
+    const response = await client.getTimer(params.timer_id);
+    return formatTimerResponse('found', response.data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export async function startTimerTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = startTimerSchema.parse(args);
+
+    const timerData: ProductiveTimerCreate = {
+      data: {
+        type: 'timers',
+        attributes: {},
+        relationships: {},
+      },
+    };
+
+    if (params.time_entry_id) {
+      timerData.data.relationships.time_entry = {
+        data: { id: params.time_entry_id, type: 'time_entries' },
+      };
+    } else if (params.service_id) {
+      timerData.data.relationships.service = {
+        data: { id: params.service_id, type: 'services' },
+      };
+    }
+
+    const response = await client.createTimer(timerData);
+    return formatTimerResponse('started', response.data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export async function stopTimerTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = stopTimerSchema.parse(args);
+    const response = await client.stopTimer(params.timer_id);
+    return formatTimerResponse('stopped', response.data);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export const getTimerDefinition = {
+  name: 'get_timer',
+  description: 'Get a timer by ID to check its status (running or stopped). Use this to verify if a timer is still running.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      timer_id: {
+        type: 'string',
+        description: 'ID of the timer to check (required)',
+      },
+    },
+    required: ['timer_id'],
+  },
+};
+
+export const startTimerDefinition = {
+  name: 'start_timer',
+  description: 'Start a new timer for time tracking. Provide a valid service_id (use list_services to find available services) or a time_entry_id to attach to an existing time entry. The service_id creates a new time entry automatically.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      service_id: {
+        type: 'string',
+        description: 'Service ID to track time against (creates new time entry). Required if time_entry_id not provided.',
+      },
+      time_entry_id: {
+        type: 'string',
+        description: 'Existing time entry ID to attach timer to. Required if service_id not provided.',
+      },
+    },
+  },
+};
+
+export const stopTimerDefinition = {
+  name: 'stop_timer',
+  description: `Stop a running timer. The timer's total_time will be added to the associated time entry.`,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      timer_id: {
+        type: 'string',
+        description: 'ID of the timer to stop (required)',
+      },
+    },
+    required: ['timer_id'],
+  },
+};

--- a/src/tools/timers.ts
+++ b/src/tools/timers.ts
@@ -13,7 +13,6 @@ const getTimerSchema = z.object({
 });
 
 const startTimerSchema = z.object({
-  service_name: z.string().optional(),
   service_id: z.string().optional(),
   time_entry_id: z.string().optional(),
   note: z.string().min(5, 'Work description must be at least 5 characters'),
@@ -47,29 +46,6 @@ function formatTimerResponse(
   }
 
   return { content: [{ type: 'text', text }] };
-}
-
-function matchServices(
-  services: Array<{ id: string; attributes: { name: string; [key: string]: unknown } }>,
-  searchName: string,
-): Array<{ id: string; attributes: { name: string; [key: string]: unknown } }> {
-  const lower = searchName.toLowerCase();
-
-  // Exact match first
-  const exact = services.filter(s => s.attributes.name.toLowerCase() === lower);
-  if (exact.length > 0) return exact;
-
-  // Contains match
-  const contains = services.filter(s => s.attributes.name.toLowerCase().includes(lower));
-  if (contains.length > 0) return contains;
-
-  // Word-based match: check if any word from the search appears in the service name
-  const searchWords = lower.split(/\s+/);
-  const wordMatch = services.filter(s => {
-    const name = s.attributes.name.toLowerCase();
-    return searchWords.some(word => word.length > 2 && name.includes(word));
-  });
-  return wordMatch;
 }
 
 function formatServicesList(
@@ -114,7 +90,7 @@ export async function startTimerTool(
 
     let resolvedServiceId = params.service_id;
 
-    // If no service_id and no time_entry_id, resolve via service_name or show list
+    // If no service_id and no time_entry_id, show available services
     if (!resolvedServiceId && !params.time_entry_id) {
       const services = await client.listServices({ budget_status: 1, limit: 200 });
 
@@ -124,39 +100,12 @@ export async function startTimerTool(
         };
       }
 
-      // If service_name provided, try to match
-      if (params.service_name) {
-        const matches = matchServices(services.data, params.service_name);
-
-        if (matches.length === 1) {
-          // Single match — use it
-          resolvedServiceId = matches[0].id;
-        } else if (matches.length > 1) {
-          // Multiple matches — ask user to choose
-          return {
-            content: [{
-              type: 'text',
-              text: `Multiple services match "${params.service_name}". Please choose one and call start_timer again with the service_id:\n\n${formatServicesList(matches)}`,
-            }],
-          };
-        } else {
-          // No match — show all
-          return {
-            content: [{
-              type: 'text',
-              text: `No service found matching "${params.service_name}". Available services (open budgets):\n\n${formatServicesList(services.data)}\n\nPlease call start_timer again with the correct service_id.`,
-            }],
-          };
-        }
-      } else {
-        // No service_name, no service_id, no time_entry_id — show all
-        return {
-          content: [{
-            type: 'text',
-            text: `Please specify a service. Available services (open budgets):\n\n${formatServicesList(services.data)}\n\nCall start_timer again with service_name or service_id.`,
-          }],
-        };
-      }
+      return {
+        content: [{
+          type: 'text',
+          text: `Please choose a service and call start_timer again with the service_id:\n\n${formatServicesList(services.data)}`,
+        }],
+      };
     }
 
     const timerData: ProductiveTimerCreate = {
@@ -272,17 +221,13 @@ export const getTimerDefinition = {
 
 export const startTimerDefinition = {
   name: 'start_timer',
-  description: 'Start a new timer for time tracking. IMPORTANT: Do NOT guess service names or IDs. If the user does not explicitly name a service from Productive.io, call this tool WITHOUT service_name or service_id to get the list of available services, then present the list to the user and let them choose. Only use service_name if the user explicitly mentioned a specific service name. A work description (note) is always required.',
+  description: 'Start a new timer for time tracking. If no service_id is provided, returns a list of available services with open budgets for the user to choose from. A work description (note) is always required.',
   inputSchema: {
     type: 'object',
     properties: {
-      service_name: {
-        type: 'string',
-        description: 'Name (or part of name) of the service to track time against. The tool will fuzzy-match against available services with open budgets.',
-      },
       service_id: {
         type: 'string',
-        description: 'Direct service ID (optional, use service_name instead if you do not know the ID).',
+        description: 'Service ID to track time against. If not provided, a list of available services will be returned.',
       },
       time_entry_id: {
         type: 'string',


### PR DESCRIPTION
## Summary

- Add `start_timer`, `stop_timer`, `get_timer` tools for real-time time tracking
- Add `budget_status` filter to `list_services` (1=open, 2=delivered)
- `start_timer` shows available services if no `service_id` provided
- After timer start, automatically sets note on the associated time entry
- Add Prettier for consistent code formatting
- Bump version to 1.0.2

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] `start_timer` without `service_id` returns service list
- [ ] `start_timer` with valid `service_id` starts timer and sets note
- [ ] `stop_timer` stops a running timer
- [ ] `get_timer` shows timer status