### PR TITLE
feat: resolve workflow status by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Restart Claude Code after configuration.
 | `create_task` | Create a task. Requires `title`. Optional `project_id`, `board_id`, `task_list_id`, `assignee_id` ("me" supported), `due_date`, `status` |
 | `update_task_assignment` | Assign/unassign a task. Requires `task_id`, `assignee_id` ("me" or "null" supported) |
 | `update_task_details` | Update title/description. Requires `task_id`, optional `title`, `description`, `description_html` |
-| `update_task_status` | Set workflow status. Requires `task_id`, `workflow_status_id` |
+| `update_task_status` | Set workflow status by name or ID. Requires `task_id` and either `status_name` (e.g. "In Progress", "On Hold") or `workflow_status_id`. Automatically resolves the task's project workflow, supports custom statuses |
 | `delete_task` | Delete a task by `task_id` |
 | `my_tasks` | Get tasks assigned to you. Optional `status`, `limit` |
 | `reposition_task` | Reorder a task within a list |
@@ -321,21 +321,31 @@ Restart Claude Code after configuration.
 
 ### Updating Task Status
 
-To update a task's status, you need to use workflow status IDs rather than simple "open"/"closed" values:
+You can update a task's status by name — no need to look up IDs:
 
-1. **First, list available workflow statuses**:
-   ```
-   list_workflow_statuses
-   ```
-   This will show you all available statuses with their IDs and categories (Not Started=1, Started=2, Closed=3).
+```
+update_task_status {
+  "task_id": "12399194",
+  "status_name": "On Hold"
+}
+```
 
-2. **Then update the task status**:
-   ```
-   update_task_status {
-     "task_id": "12399194",
-     "workflow_status_id": "specific_status_id_from_step_1"
-   }
-   ```
+The tool automatically resolves the task's project workflow and matches the status name (case-insensitive, supports partial matching). This works with custom workflow statuses too.
+
+If the name doesn't match or is ambiguous, it returns the available statuses for that project:
+
+```
+No workflow status matching "banana" found.
+
+Available statuses:
+  • "Pending" (ID: 102305) — Not Started
+  • "Open" (ID: 102291) — Started
+  • "On Hold" (ID: 102306) — Started
+  • "Waiting" (ID: 102307) — Started
+  • "Closed" (ID: 102292) — Closed
+```
+
+You can also pass `workflow_status_id` directly if you already know the ID.
 
 ### Working with "me" Context
 
@@ -352,7 +362,7 @@ When `PRODUCTIVE_USER_ID` is configured, you can use "me" in several tools:
 3. **Create tasks**: `create_task`
 4. **Break down work**: `create_subtask` for sub-items, `create_todo` for checklists
 5. **Add comments**: `add_task_comment`
-6. **Update status**: Use `list_workflow_statuses` then `update_task_status`
+6. **Update status**: `update_task_status` with `status_name` (e.g. "Open", "On Hold", "Closed")
 7. **Track progress**: Use `list_activities` or `get_recent_updates`
 
 ### Building Documentation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "productive-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "main": "./build/index.js",
   "bin": {

--- a/src/tools/task-status.ts
+++ b/src/tools/task-status.ts
@@ -1,12 +1,89 @@
 import { z } from 'zod';
 import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { ProductiveTaskUpdate } from '../api/types.js';
+import { ProductiveTaskUpdate, ProductiveIncludedResource } from '../api/types.js';
+import { getConfig } from '../config/index.js';
 
 const updateTaskStatusSchema = z.object({
   task_id: z.string().min(1, 'Task ID is required'),
-  workflow_status_id: z.string().min(1, 'Workflow status ID is required'),
+  workflow_status_id: z.string().optional().describe('Exact workflow status ID (use if known)'),
+  status_name: z.string().optional().describe('Status name to match, e.g. "In Progress", "Done", "QA Review"'),
 });
+
+/**
+ * Resolves the workflow for a task by going through its project,
+ * then lists all statuses in that workflow (including custom ones).
+ * Path: task → project (include=workflow) → workflow_id → list statuses
+ */
+async function resolveWorkflowStatuses(
+  taskId: string
+): Promise<{ workflowId: string; statuses: Array<{ id: string; name: string; categoryId: number }> }> {
+  const cfg = getConfig();
+  const headers = {
+    'X-Auth-Token': cfg.PRODUCTIVE_API_TOKEN,
+    'X-Organization-Id': cfg.PRODUCTIVE_ORG_ID,
+    'Content-Type': 'application/vnd.api+json',
+  };
+
+  // Step 1: Get the task with project included to find its project ID
+  const taskRes = await fetch(
+    `${cfg.PRODUCTIVE_API_BASE_URL}tasks/${taskId}?include=project`,
+    { headers }
+  );
+  if (!taskRes.ok) {
+    throw new Error(`Failed to fetch task ${taskId}: ${taskRes.status}`);
+  }
+  const taskData = await taskRes.json();
+  const projectId = taskData.data?.relationships?.project?.data?.id;
+  if (!projectId) {
+    throw new Error('Task has no project assigned');
+  }
+
+  // Step 2: Get the project with workflow included to find workflow_id
+  const projRes = await fetch(
+    `${cfg.PRODUCTIVE_API_BASE_URL}projects/${projectId}?include=workflow`,
+    { headers }
+  );
+  if (!projRes.ok) {
+    throw new Error(`Failed to fetch project ${projectId}: ${projRes.status}`);
+  }
+  const projData = await projRes.json();
+  const workflowId = projData.data?.relationships?.workflow?.data?.id;
+  if (!workflowId) {
+    throw new Error('Project has no workflow configured');
+  }
+
+  // Step 3: List all statuses in this workflow
+  const statusRes = await fetch(
+    `${cfg.PRODUCTIVE_API_BASE_URL}workflow_statuses?filter[workflow_id]=${workflowId}&page[size]=200`,
+    { headers }
+  );
+  if (!statusRes.ok) {
+    throw new Error(`Failed to fetch workflow statuses: ${statusRes.status}`);
+  }
+  const statusData = await statusRes.json();
+
+  const statuses = statusData.data.map((s: ProductiveIncludedResource) => ({
+    id: s.id,
+    name: s.attributes.name as string,
+    categoryId: s.attributes.category_id as number,
+  }));
+
+  return { workflowId, statuses };
+}
+
+function categoryLabel(categoryId: number): string {
+  if (categoryId === 1) return 'Not Started';
+  if (categoryId === 2) return 'Started';
+  if (categoryId === 3) return 'Closed';
+  return `Category ${categoryId}`;
+}
+
+function formatStatusList(statuses: Array<{ id: string; name: string; categoryId: number }>): string {
+  return statuses
+    .map(s => `  • "${s.name}" (ID: ${s.id}) — ${categoryLabel(s.categoryId)}`)
+    .join('\n');
+}
 
 export async function updateTaskStatusTool(
   client: ProductiveAPIClient,
@@ -14,7 +91,64 @@ export async function updateTaskStatusTool(
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = updateTaskStatusSchema.parse(args);
-    
+
+    if (!params.workflow_status_id && !params.status_name) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'Either workflow_status_id or status_name must be provided'
+      );
+    }
+
+    let resolvedStatusId = params.workflow_status_id;
+    let resolvedStatusName = '';
+
+    // If status_name provided, resolve it to an ID
+    if (params.status_name && !resolvedStatusId) {
+      const { statuses } = await resolveWorkflowStatuses(params.task_id);
+      const needle = params.status_name.toLowerCase().trim();
+
+      // 1. Exact match (case-insensitive)
+      let matches = statuses.filter(s => s.name.toLowerCase() === needle);
+
+      // 2. Starts-with match
+      if (matches.length === 0) {
+        matches = statuses.filter(s => s.name.toLowerCase().startsWith(needle));
+      }
+
+      // 3. Contains match
+      if (matches.length === 0) {
+        matches = statuses.filter(s => s.name.toLowerCase().includes(needle));
+      }
+
+      if (matches.length === 0) {
+        return {
+          content: [{
+            type: 'text',
+            text: `No workflow status matching "${params.status_name}" found.\n\nAvailable statuses:\n${formatStatusList(statuses)}`,
+          }],
+        };
+      }
+
+      if (matches.length > 1) {
+        // Check if one is an exact match among the multiple
+        const exact = matches.filter(s => s.name.toLowerCase() === needle);
+        if (exact.length === 1) {
+          matches = exact;
+        } else {
+          return {
+            content: [{
+              type: 'text',
+              text: `Multiple statuses match "${params.status_name}":\n${formatStatusList(matches)}\n\nPlease be more specific, or use the workflow_status_id directly.`,
+            }],
+          };
+        }
+      }
+
+      resolvedStatusId = matches[0].id;
+      resolvedStatusName = matches[0].name;
+    }
+
+    // Apply the status
     const taskUpdate: ProductiveTaskUpdate = {
       data: {
         type: 'tasks',
@@ -22,34 +156,36 @@ export async function updateTaskStatusTool(
         relationships: {
           workflow_status: {
             data: {
-              id: params.workflow_status_id,
+              id: resolvedStatusId!,
               type: 'workflow_statuses',
             },
           },
         },
       },
     };
-    
+
     const response = await client.updateTask(params.task_id, taskUpdate);
-    
+
     let text = `Task status updated successfully!\n`;
     text += `Task: ${response.data.attributes.title} (ID: ${response.data.id})\n`;
-    text += `Workflow Status ID: ${params.workflow_status_id}`;
-    
-    // Check for status information in the response
-    if (response.data.attributes.closed !== undefined) {
-      const statusText = response.data.attributes.closed ? 'closed' : 'open';
-      text += `\nActual Status: ${statusText}`;
+    if (resolvedStatusName) {
+      text += `Status: ${resolvedStatusName} (ID: ${resolvedStatusId})`;
+    } else {
+      text += `Workflow Status ID: ${resolvedStatusId}`;
     }
-    
+
+    if (response.data.attributes.closed !== undefined) {
+      text += `\nTask is now: ${response.data.attributes.closed ? 'closed' : 'open'}`;
+    }
+
     if (response.data.attributes.updated_at) {
       text += `\nUpdated at: ${response.data.attributes.updated_at}`;
     }
-    
+
     return {
       content: [{
         type: 'text',
-        text: text,
+        text,
       }],
     };
   } catch (error) {
@@ -59,7 +195,9 @@ export async function updateTaskStatusTool(
         `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
       );
     }
-    
+
+    if (error instanceof McpError) throw error;
+
     throw new McpError(
       ErrorCode.InternalError,
       error instanceof Error ? error.message : 'Unknown error occurred'
@@ -69,7 +207,7 @@ export async function updateTaskStatusTool(
 
 export const updateTaskStatusDefinition = {
   name: 'update_task_status',
-  description: 'Update the status of a task in Productive.io using workflow status ID. Use list_workflow_statuses to see available status IDs.',
+  description: 'Update the status of a task in Productive.io. You can provide a status_name (e.g. "In Progress", "Done", "QA Review") and it will automatically resolve to the correct workflow status for that task. Supports custom workflow statuses. Falls back to workflow_status_id if provided directly.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -77,11 +215,15 @@ export const updateTaskStatusDefinition = {
         type: 'string',
         description: 'ID of the task to update (required)',
       },
+      status_name: {
+        type: 'string',
+        description: 'Name of the status to set (e.g. "In Progress", "Done", "To Do"). Case-insensitive, supports partial matching. If ambiguous, returns available options.',
+      },
       workflow_status_id: {
         type: 'string',
-        description: 'ID of the workflow status to set (use list_workflow_statuses to see available options)',
+        description: 'Exact workflow status ID (optional — use status_name instead for convenience)',
       },
     },
-    required: ['task_id', 'workflow_status_id'],
+    required: ['task_id'],
   },
 };


### PR DESCRIPTION
## Summary
- `update_task_status` now accepts `status_name` (e.g. "Open", "On Hold", "Closed") instead of requiring raw `workflow_status_id`
- Automatically resolves the task's project workflow and matches by name (case-insensitive, partial matching)
- Works with custom workflow statuses — queries the actual project workflow, not a hardcoded list
- If no match or ambiguous, returns available statuses to choose from
- `workflow_status_id` still works for direct ID usage
- Updates README docs and workflow examples
- Bumps version to 1.1.1

## Test plan
- [x] Exact name match: `"Open"` resolves correctly
- [x] Case-insensitive: `"CLOSED"` matches "Closed"
- [x] Partial match: `"hold"` matches "On Hold"
- [x] Non-existent status: returns available options list
- [x] Status transitions verified (Pending → Open → On Hold → Closed → Pending)
- [x] TypeScript builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)