### PR TITLE
feat: add task dependency tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,15 @@ Restart Claude Code after configuration.
 | `move_task_to_list` | Move a task to a different task list |
 | `add_to_backlog` | Move a task to the backlog |
 
+### Task Dependency Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_task_dependencies` | List dependencies for a task. Filter by `task_id` (what it blocks) or `dependent_task_id` (what blocks it) |
+| `get_task_dependency` | Get dependency details by `dependency_id` |
+| `create_task_dependency` | Create a dependency. Requires `task_id` (blocker), `dependent_task_id` (blocked). Optional `type_id`: 1 = blocks (default), 2 = is blocked by, 3 = related to |
+| `delete_task_dependency` | Remove a dependency by `dependency_id` |
+
 ### Subtask Tools
 
 | Tool | Description |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "productive-mcp",
-  "version": "1.2.0",
+  "version": "1.1.2",
   "type": "module",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "productive-mcp",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "main": "./build/index.js",
   "bin": {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -31,6 +31,8 @@ import {
   ProductiveTodoUpdate,
   ProductivePageCreate,
   ProductivePageUpdate,
+  ProductiveTaskDependency,
+  ProductiveTaskDependencyCreate,
   ProductiveError
 } from './types.js';
 
@@ -1081,5 +1083,42 @@ export class ProductiveAPIClient {
         data: { type: 'pages', attributes },
       }),
     });
+  }
+
+  // ---- Task Dependency methods ----
+
+  async listTaskDependencies(params?: {
+    task_id?: string;
+    dependent_task_id?: string;
+    type_id?: number;
+    limit?: number;
+    page?: number;
+  }): Promise<ProductiveResponse<ProductiveTaskDependency>> {
+    const q = new URLSearchParams();
+    q.append('include', 'task,dependent_task');
+    if (params?.task_id) q.append('filter[task_id]', params.task_id);
+    if (params?.dependent_task_id) q.append('filter[dependent_task_id]', params.dependent_task_id);
+    if (params?.type_id) q.append('filter[type_id]', params.type_id.toString());
+    if (params?.limit) q.append('page[size]', params.limit.toString());
+    if (params?.page) q.append('page[number]', params.page.toString());
+    const qs = q.toString();
+    return this.makeRequest<ProductiveResponse<ProductiveTaskDependency>>(`task_dependencies${qs ? `?${qs}` : ''}`);
+  }
+
+  async getTaskDependency(dependencyId: string): Promise<ProductiveSingleResponse<ProductiveTaskDependency>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTaskDependency>>(
+      `task_dependencies/${dependencyId}?include=task,dependent_task`
+    );
+  }
+
+  async createTaskDependency(data: ProductiveTaskDependencyCreate): Promise<ProductiveSingleResponse<ProductiveTaskDependency>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTaskDependency>>('task_dependencies', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteTaskDependency(dependencyId: string): Promise<void> {
+    return this.makeVoidRequest(`task_dependencies/${dependencyId}`, { method: 'DELETE' });
   }
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -683,6 +683,36 @@ export interface ProductiveCommentUpdate {
   };
 }
 
+// ---- Task Dependency types ----
+
+export interface ProductiveTaskDependency {
+  id: string;
+  type: 'task_dependencies';
+  attributes: {
+    type_id: number;
+    created_at?: string;
+    updated_at?: string;
+    [key: string]: unknown;
+  };
+  relationships?: {
+    task?: { data: { id: string; type: 'tasks' } };
+    dependent_task?: { data: { id: string; type: 'tasks' } };
+    reverse_dependency?: { data: { id: string; type: 'task_dependencies' } };
+    [key: string]: unknown;
+  };
+}
+
+export interface ProductiveTaskDependencyCreate {
+  data: {
+    type: 'task_dependencies';
+    attributes: {
+      task_id: string;
+      dependent_task_id: string;
+      type_id: string;
+    };
+  };
+}
+
 // ---- Error types ----
 
 export interface ProductiveError {

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ import { listFolders, listFoldersTool, getFolder, getFolderTool, createFolder, c
 import { listSubtasksTool, listSubtasksDefinition, createSubtaskTool, createSubtaskDefinition } from './tools/subtasks.js';
 import { listTodosTool, listTodosDefinition, getTodoTool, getTodoDefinition, createTodoTool, createTodoDefinition, updateTodoTool, updateTodoDefinition, deleteTodoTool, deleteTodoDefinition } from './tools/todos.js';
 import { listPagesTool, listPagesDefinition, getPageTool, getPageDefinition, createPageTool, createPageDefinition, updatePageTool, updatePageDefinition, deletePageTool, deletePageDefinition, movePageTool, movePageDefinition, copyPageTool, copyPageDefinition } from './tools/pages.js';
+import { listTaskDependenciesTool, listTaskDependenciesDefinition, getTaskDependencyTool, getTaskDependencyDefinition, createTaskDependencyTool, createTaskDependencyDefinition, deleteTaskDependencyTool, deleteTaskDependencyDefinition } from './tools/task-dependencies.js';
 
 export async function createServer() {
   // Initialize API client and config early to check user context
@@ -119,6 +120,11 @@ export async function createServer() {
       deletePageDefinition,
       movePageDefinition,
       copyPageDefinition,
+      // Task Dependencies
+      listTaskDependenciesDefinition,
+      getTaskDependencyDefinition,
+      createTaskDependencyDefinition,
+      deleteTaskDependencyDefinition,
     ],
   }));
   
@@ -303,6 +309,16 @@ export async function createServer() {
         return await movePageTool(apiClient, args);
       case 'copy_page':
         return await copyPageTool(apiClient, args);
+
+      // Task Dependencies
+      case 'list_task_dependencies':
+        return await listTaskDependenciesTool(apiClient, args);
+      case 'get_task_dependency':
+        return await getTaskDependencyTool(apiClient, args);
+      case 'create_task_dependency':
+        return await createTaskDependencyTool(apiClient, args);
+      case 'delete_task_dependency':
+        return await deleteTaskDependencyTool(apiClient, args);
 
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/src/tools/task-dependencies.ts
+++ b/src/tools/task-dependencies.ts
@@ -1,0 +1,257 @@
+import { z } from 'zod';
+import { ProductiveAPIClient } from '../api/client.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ProductiveIncludedResource } from '../api/types.js';
+
+function resolveTaskTitle(taskId: string | undefined, included?: ProductiveIncludedResource[]): string | undefined {
+  if (!taskId || !included) return undefined;
+  const task = included.find(item => item.type === 'tasks' && item.id === taskId);
+  return task?.attributes?.title as string | undefined;
+}
+
+function dependencyTypeLabel(typeId: number): string {
+  switch (typeId) {
+    case 1: return 'blocks (finish to start)';
+    case 2: return 'is blocked by';
+    case 3: return 'related to';
+    default: return `type ${typeId}`;
+  }
+}
+
+// ---- Schemas ----
+
+const listTaskDependenciesSchema = z.object({
+  task_id: z.string().optional().describe('Filter by source task ID (the blocker)'),
+  dependent_task_id: z.string().optional().describe('Filter by dependent task ID (the blocked task)'),
+  limit: z.number().min(1).max(200).default(50).optional(),
+});
+
+const getTaskDependencySchema = z.object({
+  dependency_id: z.string().min(1, 'Dependency ID is required'),
+});
+
+const createTaskDependencySchema = z.object({
+  task_id: z.string().min(1, 'Task ID is required (the blocker)'),
+  dependent_task_id: z.string().min(1, 'Dependent task ID is required (the blocked task)'),
+  type_id: z.number().min(1).max(3).default(1).describe('1 = blocks (finish to start), 2 = is blocked by, 3 = related to'),
+});
+
+const deleteTaskDependencySchema = z.object({
+  dependency_id: z.string().min(1, 'Dependency ID is required'),
+});
+
+// ---- Handlers ----
+
+export async function listTaskDependenciesTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = listTaskDependenciesSchema.parse(args || {});
+
+    const response = await client.listTaskDependencies({
+      task_id: params.task_id,
+      dependent_task_id: params.dependent_task_id,
+      limit: params.limit,
+    });
+
+    if (!response.data || response.data.length === 0) {
+      return {
+        content: [{
+          type: 'text',
+          text: 'No task dependencies found.',
+        }],
+      };
+    }
+
+    const depsText = response.data.map(dep => {
+      const taskId = dep.relationships?.task?.data?.id;
+      const depTaskId = dep.relationships?.dependent_task?.data?.id;
+      const taskTitle = resolveTaskTitle(taskId, response.included);
+      const depTaskTitle = resolveTaskTitle(depTaskId, response.included);
+      const typeLabel = dependencyTypeLabel(dep.attributes.type_id);
+
+      const taskDisplay = taskTitle ? `${taskTitle} (ID: ${taskId})` : `Task ${taskId}`;
+      const depDisplay = depTaskTitle ? `${depTaskTitle} (ID: ${depTaskId})` : `Task ${depTaskId}`;
+
+      return `- Dependency ID: ${dep.id}\n  ${taskDisplay} → ${typeLabel} → ${depDisplay}\n  Type ID: ${dep.attributes.type_id}`;
+    }).join('\n\n');
+
+    return {
+      content: [{
+        type: 'text',
+        text: `Found ${response.data.length} dependency(ies):\n\n${depsText}`,
+      }],
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(ErrorCode.InvalidParams, `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`);
+    }
+    throw new McpError(ErrorCode.InternalError, error instanceof Error ? error.message : 'Unknown error occurred');
+  }
+}
+
+export async function getTaskDependencyTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = getTaskDependencySchema.parse(args);
+    const response = await client.getTaskDependency(params.dependency_id);
+    const dep = response.data;
+
+    const taskId = dep.relationships?.task?.data?.id;
+    const depTaskId = dep.relationships?.dependent_task?.data?.id;
+    const taskTitle = resolveTaskTitle(taskId, response.included);
+    const depTaskTitle = resolveTaskTitle(depTaskId, response.included);
+    const typeLabel = dependencyTypeLabel(dep.attributes.type_id);
+
+    let text = `Dependency ID: ${dep.id}\n`;
+    text += `Type: ${typeLabel} (type_id: ${dep.attributes.type_id})\n`;
+    text += `Task: ${taskTitle || 'Unknown'} (ID: ${taskId})\n`;
+    text += `Dependent task: ${depTaskTitle || 'Unknown'} (ID: ${depTaskId})\n`;
+    if (dep.attributes.created_at) text += `Created at: ${dep.attributes.created_at}`;
+
+    return { content: [{ type: 'text', text }] };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(ErrorCode.InvalidParams, `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`);
+    }
+    throw new McpError(ErrorCode.InternalError, error instanceof Error ? error.message : 'Unknown error occurred');
+  }
+}
+
+export async function createTaskDependencyTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = createTaskDependencySchema.parse(args);
+
+    const response = await client.createTaskDependency({
+      data: {
+        type: 'task_dependencies',
+        attributes: {
+          task_id: params.task_id,
+          dependent_task_id: params.dependent_task_id,
+          type_id: params.type_id.toString(),
+        },
+      },
+    });
+
+    const dep = response.data;
+    const typeLabel = dependencyTypeLabel(dep.attributes.type_id);
+
+    let text = `Task dependency created successfully!\n`;
+    text += `Dependency ID: ${dep.id}\n`;
+    text += `Type: ${typeLabel}\n`;
+    text += `Task ${params.task_id} → ${typeLabel} → Task ${params.dependent_task_id}`;
+
+    return { content: [{ type: 'text', text }] };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(ErrorCode.InvalidParams, `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`);
+    }
+    throw new McpError(ErrorCode.InternalError, error instanceof Error ? error.message : 'Unknown error occurred');
+  }
+}
+
+export async function deleteTaskDependencyTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = deleteTaskDependencySchema.parse(args);
+    await client.deleteTaskDependency(params.dependency_id);
+
+    return {
+      content: [{
+        type: 'text',
+        text: `Task dependency ${params.dependency_id} deleted successfully.`,
+      }],
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(ErrorCode.InvalidParams, `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`);
+    }
+    throw new McpError(ErrorCode.InternalError, error instanceof Error ? error.message : 'Unknown error occurred');
+  }
+}
+
+// ---- Definitions ----
+
+export const listTaskDependenciesDefinition = {
+  name: 'list_task_dependencies',
+  description: 'List task dependencies (blockers/related tasks). Filter by task_id to see what a task blocks, or dependent_task_id to see what blocks a task.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      task_id: {
+        type: 'string',
+        description: 'Filter by source task ID — shows tasks that this task blocks',
+      },
+      dependent_task_id: {
+        type: 'string',
+        description: 'Filter by dependent task ID — shows tasks that block this task',
+      },
+      limit: {
+        type: 'number',
+        description: 'Number of results to return (1-200, default: 50)',
+      },
+    },
+  },
+};
+
+export const getTaskDependencyDefinition = {
+  name: 'get_task_dependency',
+  description: 'Get details of a specific task dependency by ID.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      dependency_id: {
+        type: 'string',
+        description: 'ID of the task dependency to retrieve (required)',
+      },
+    },
+    required: ['dependency_id'],
+  },
+};
+
+export const createTaskDependencyDefinition = {
+  name: 'create_task_dependency',
+  description: 'Create a dependency between two tasks. Use type_id 1 for "blocks" (task must finish before dependent_task can start), 2 for "is blocked by", 3 for "related to".',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      task_id: {
+        type: 'string',
+        description: 'ID of the source task (the blocker) — required',
+      },
+      dependent_task_id: {
+        type: 'string',
+        description: 'ID of the dependent task (the blocked task) — required',
+      },
+      type_id: {
+        type: 'number',
+        description: 'Dependency type: 1 = blocks (finish to start), 2 = is blocked by, 3 = related to. Default: 1',
+        default: 1,
+      },
+    },
+    required: ['task_id', 'dependent_task_id'],
+  },
+};
+
+export const deleteTaskDependencyDefinition = {
+  name: 'delete_task_dependency',
+  description: 'Delete a task dependency by ID.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      dependency_id: {
+        type: 'string',
+        description: 'ID of the task dependency to delete (required)',
+      },
+    },
+    required: ['dependency_id'],
+  },
+};


### PR DESCRIPTION
## Summary
- 4 new MCP tools: `list_task_dependencies`, `get_task_dependency`, `create_task_dependency`, `delete_task_dependency`
- Supports 3 dependency types: blocks (1), is blocked by (2), related to (3)
- Resolves task titles in list/get output via includes
- Productive auto-creates reverse dependencies — both directions are queryable
- Bumps version to 1.2.0

## Test plan
- [x] All 3 type_ids create successfully
- [x] List by task_id and dependent_task_id both return correct results
- [x] Get returns full dependency details with task relationships
- [x] Delete removes the dependency
- [x] Reverse dependencies auto-created by Productive confirmed
- [x] TypeScript builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)