### PR TITLE
feat: add people listing and lookup tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ dist/
 .env.local
 .env.production
 
+# MCP config (contains API tokens)
+.mcp.json
+
 # Logs
 logs/
 *.log

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -306,7 +306,11 @@ export class ProductiveAPIClient {
     
     return this.makeRequest<ProductiveResponse<ProductivePerson>>(path);
   }
-  
+
+  async getPerson(personId: string): Promise<ProductiveSingleResponse<ProductivePerson>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductivePerson>>(`people/${personId}`);
+  }
+
   async getTask(taskId: string): Promise<ProductiveSingleResponse<ProductiveTask>> {
     return this.makeRequest<ProductiveSingleResponse<ProductiveTask>>(`tasks/${taskId}`);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ import { listFolders, listFoldersTool, getFolder, getFolderTool, createFolder, c
 import { listSubtasksTool, listSubtasksDefinition, createSubtaskTool, createSubtaskDefinition } from './tools/subtasks.js';
 import { listTodosTool, listTodosDefinition, getTodoTool, getTodoDefinition, createTodoTool, createTodoDefinition, updateTodoTool, updateTodoDefinition, deleteTodoTool, deleteTodoDefinition } from './tools/todos.js';
 import { listPagesTool, listPagesDefinition, getPageTool, getPageDefinition, createPageTool, createPageDefinition, updatePageTool, updatePageDefinition, deletePageTool, deletePageDefinition, movePageTool, movePageDefinition, copyPageTool, copyPageDefinition } from './tools/pages.js';
+import { listPeopleTool, listPeopleDefinition, getPersonTool, getPersonDefinition } from './tools/people.js';
 
 export async function createServer() {
   // Initialize API client and config early to check user context
@@ -119,6 +120,9 @@ export async function createServer() {
       deletePageDefinition,
       movePageDefinition,
       copyPageDefinition,
+      // People
+      listPeopleDefinition,
+      getPersonDefinition,
     ],
   }));
   
@@ -303,6 +307,12 @@ export async function createServer() {
         return await movePageTool(apiClient, args);
       case 'copy_page':
         return await copyPageTool(apiClient, args);
+
+      case 'list_people':
+        return await listPeopleTool(apiClient, args);
+
+      case 'get_person':
+        return await getPersonTool(apiClient, args);
 
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/src/tools/people.ts
+++ b/src/tools/people.ts
@@ -1,0 +1,177 @@
+import { z } from 'zod';
+import { ProductiveAPIClient } from '../api/client.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+
+const listPeopleSchema = z.object({
+  company_id: z.string().optional(),
+  project_id: z.string().optional(),
+  is_active: z.boolean().default(true).optional(),
+  email: z.string().optional(),
+  limit: z.number().min(1).max(200).default(30).optional(),
+});
+
+const getPersonSchema = z.object({
+  person_id: z.string().min(1, 'Person ID is required'),
+});
+
+export async function listPeopleTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = listPeopleSchema.parse(args || {});
+
+    const response = await client.listPeople({
+      company_id: params.company_id,
+      project_id: params.project_id,
+      is_active: params.is_active,
+      email: params.email,
+      limit: params.limit,
+    });
+
+    if (!response || !response.data || response.data.length === 0) {
+      return {
+        content: [{
+          type: 'text',
+          text: 'No people found matching the criteria.',
+        }],
+      };
+    }
+
+    const peopleText = response.data.filter(person => person && person.attributes).map(person => {
+      const attrs = person.attributes;
+      const name = `${attrs.first_name} ${attrs.last_name}`.trim();
+      const lines = [`• ${name} (ID: ${person.id})`];
+
+      if (attrs.email) lines.push(`  Email: ${attrs.email}`);
+      if (attrs.title) lines.push(`  Title: ${attrs.title}`);
+      if (attrs.role) lines.push(`  Role: ${attrs.role}`);
+      if (attrs.is_active !== undefined) lines.push(`  Active: ${attrs.is_active}`);
+
+      return lines.join('\n');
+    }).join('\n\n');
+
+    const summary = `Found ${response.data.length} ${response.data.length !== 1 ? 'people' : 'person'}${response.meta?.total_count ? ` (showing ${response.data.length} of ${response.meta.total_count})` : ''}:\n\n${peopleText}`;
+
+    return {
+      content: [{
+        type: 'text',
+        text: summary,
+      }],
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export async function getPersonTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = getPersonSchema.parse(args);
+
+    const response = await client.getPerson(params.person_id);
+
+    if (!response || !response.data) {
+      return {
+        content: [{
+          type: 'text',
+          text: `No person found with ID: ${params.person_id}`,
+        }],
+      };
+    }
+
+    const person = response.data;
+    const attrs = person.attributes;
+    const name = `${attrs.first_name} ${attrs.last_name}`.trim();
+
+    const lines = [
+      `${name} (ID: ${person.id})`,
+      `Email: ${attrs.email}`,
+    ];
+
+    if (attrs.title) lines.push(`Title: ${attrs.title}`);
+    if (attrs.role) lines.push(`Role: ${attrs.role}`);
+    if (attrs.is_active !== undefined) lines.push(`Active: ${attrs.is_active}`);
+    if (attrs.created_at) lines.push(`Created: ${attrs.created_at}`);
+
+    return {
+      content: [{
+        type: 'text',
+        text: lines.join('\n'),
+      }],
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export const listPeopleDefinition = {
+  name: 'list_people',
+  description: 'List people/members in the organization. Use project_id to see who is on a specific project. Returns person IDs that can be used with update_task_assignment.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      company_id: {
+        type: 'string',
+        description: 'Filter people by company ID',
+      },
+      project_id: {
+        type: 'string',
+        description: 'Filter people by project ID (shows who is on a project)',
+      },
+      is_active: {
+        type: 'boolean',
+        description: 'Filter by active status (default: true)',
+        default: true,
+      },
+      email: {
+        type: 'string',
+        description: 'Filter by email address',
+      },
+      limit: {
+        type: 'number',
+        description: 'Number of people to return (1-200)',
+        minimum: 1,
+        maximum: 200,
+        default: 30,
+      },
+    },
+  },
+};
+
+export const getPersonDefinition = {
+  name: 'get_person',
+  description: 'Get details of a specific person by their ID.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      person_id: {
+        type: 'string',
+        description: 'The ID of the person to retrieve',
+      },
+    },
+    required: ['person_id'],
+  },
+};


### PR DESCRIPTION
## Summary

- Adds `list_people` tool to discover people/members in the org, with filtering by project, company, email, and active status
- Adds `get_person` tool to retrieve details of a specific person by ID
- Enables the workflow: list people → get person ID → assign task (previously `update_task_assignment` required an ID with no way to discover one)

Closes #17

## Test plan

- [x] `npm run build` passes cleanly
- [x] `list_people` with `project_id` returns project members
- [x] `get_person` returns person details by ID
- [x] Person IDs from results are compatible with `update_task_assignment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)