### PR TITLE
feat: support posting hidden (internal) comments on tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Restart Claude Code after configuration.
 
 | Tool | Description |
 |------|-------------|
-| `add_task_comment` | Add a comment to a task. Requires `task_id`, `comment` (supports HTML) |
+| `add_task_comment` | Add a comment to a task. Requires `task_id`, `comment` (supports HTML and @mentions). Optional `hidden` (boolean) posts an internal comment not visible to clients in the client portal |
 | `list_comments` | List comments. Filter by `task_id`, `project_id`, `limit` |
 | `get_comment` | Get full comment details by `comment_id` |
 | `update_comment` | Edit a comment. Requires `comment_id`, `body` |

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -346,6 +346,7 @@ export interface ProductiveCommentCreate {
     type: 'comments';
     attributes: {
       body: string;
+      hidden?: boolean;
     };
     relationships: {
       task: {

--- a/src/tools/__tests__/comments.test.ts
+++ b/src/tools/__tests__/comments.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { addTaskCommentTool } from '../comments.js';
+import { ProductiveAPIClient } from '../../api/client.js';
+import { ProductiveComment, ProductiveCommentCreate } from '../../api/types.js';
+
+/**
+ * Builds a mock comments API response echoing the submitted body and hidden flag.
+ */
+function makeCommentResponse(body: string, hidden?: boolean): { data: ProductiveComment } {
+  return {
+    data: {
+      id: '999',
+      type: 'comments',
+      attributes: {
+        body,
+        commentable_type: 'task',
+        created_at: '2026-05-28T10:00:00Z',
+        updated_at: '2026-05-28T10:00:00Z',
+        ...(hidden !== undefined ? { hidden } : {}),
+      },
+    },
+  };
+}
+
+/**
+ * Mock client capturing the createComment payload and returning an echo response.
+ * listPeople is stubbed so mention resolution never hits the network.
+ */
+function mockClient(): { client: ProductiveAPIClient; createComment: ReturnType<typeof vi.fn> } {
+  const createComment = vi.fn((data: ProductiveCommentCreate) =>
+    Promise.resolve(makeCommentResponse(data.data.attributes.body, data.data.attributes.hidden))
+  );
+  const client = {
+    createComment,
+    listPeople: vi.fn().mockResolvedValue({ data: [] }),
+  } as unknown as ProductiveAPIClient;
+  return { client, createComment };
+}
+
+describe('addTaskCommentTool - hidden parameter', () => {
+  it('sends hidden:true when hidden is set to true', async () => {
+    const { client, createComment } = mockClient();
+
+    const result = await addTaskCommentTool(client, {
+      task_id: '123',
+      comment: 'Internal note',
+      hidden: true,
+    });
+
+    expect(createComment).toHaveBeenCalledTimes(1);
+    const payload = createComment.mock.calls[0][0] as ProductiveCommentCreate;
+    expect(payload.data.attributes.hidden).toBe(true);
+    expect(result.content[0].text).toContain('Hidden comment added successfully');
+    expect(result.content[0].text).toContain('Hidden: true');
+  });
+
+  it('sends hidden:false when hidden is set to false', async () => {
+    const { client, createComment } = mockClient();
+
+    const result = await addTaskCommentTool(client, {
+      task_id: '123',
+      comment: 'Visible note',
+      hidden: false,
+    });
+
+    const payload = createComment.mock.calls[0][0] as ProductiveCommentCreate;
+    expect(payload.data.attributes.hidden).toBe(false);
+    expect(result.content[0].text).toContain('Comment added successfully');
+    expect(result.content[0].text).not.toContain('Hidden comment added successfully');
+  });
+
+  it('omits the hidden attribute entirely when not provided', async () => {
+    const { client, createComment } = mockClient();
+
+    await addTaskCommentTool(client, {
+      task_id: '123',
+      comment: 'Default note',
+    });
+
+    const payload = createComment.mock.calls[0][0] as ProductiveCommentCreate;
+    expect('hidden' in payload.data.attributes).toBe(false);
+  });
+
+  it('attaches the comment to the correct task', async () => {
+    const { client, createComment } = mockClient();
+
+    await addTaskCommentTool(client, {
+      task_id: '456',
+      comment: 'Note',
+      hidden: true,
+    });
+
+    const payload = createComment.mock.calls[0][0] as ProductiveCommentCreate;
+    expect(payload.data.relationships.task.data.id).toBe('456');
+    expect(payload.data.relationships.task.data.type).toBe('tasks');
+  });
+
+  it('rejects a non-boolean hidden value', async () => {
+    const { client } = mockClient();
+
+    await expect(
+      addTaskCommentTool(client, {
+        task_id: '123',
+        comment: 'Note',
+        hidden: 'yes',
+      })
+    ).rejects.toThrow(/Invalid parameters/);
+  });
+});

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -44,6 +44,7 @@ function buildAmbiguousError(result: MentionResolutionResult): string {
 const addTaskCommentSchema = z.object({
   task_id: z.string().min(1, 'Task ID is required'),
   comment: z.string().min(1, 'Comment text is required'),
+  hidden: z.boolean().optional(),
 });
 
 export async function addTaskCommentTool(
@@ -68,6 +69,7 @@ export async function addTaskCommentTool(
         type: 'comments' as const,
         attributes: {
           body: mentionResult.resolvedBody,
+          ...(params.hidden !== undefined ? { hidden: params.hidden } : {}),
         },
         relationships: {
           task: {
@@ -82,10 +84,13 @@ export async function addTaskCommentTool(
 
     const response = await client.createComment(commentData);
 
-    let text = `Comment added successfully!\n`;
+    let text = params.hidden ? `Hidden comment added successfully!\n` : `Comment added successfully!\n`;
     text += `Task ID: ${params.task_id}\n`;
     text += `Comment: ${response.data.attributes.body}\n`;
     text += `Comment ID: ${response.data.id}`;
+    if (response.data.attributes.hidden !== undefined) {
+      text += `\nHidden: ${response.data.attributes.hidden}`;
+    }
     if (response.data.attributes.created_at) {
       text += `\nCreated at: ${response.data.attributes.created_at}`;
     }
@@ -114,7 +119,7 @@ export async function addTaskCommentTool(
 
 export const addTaskCommentDefinition = {
   name: 'add_task_comment',
-  description: 'Add a comment to a task in Productive.io. Supports HTML formatting and @mentions (e.g. @Jarrod Lawson). Mentions are automatically resolved to notify the mentioned person.',
+  description: 'Add a comment to a task in Productive.io. Supports HTML formatting and @mentions (e.g. @Jarrod Lawson). Mentions are automatically resolved to notify the mentioned person. Set hidden to true to post an internal comment that is not visible to clients in the client portal (hidden comments are not available in internal projects).',
   inputSchema: {
     type: 'object',
     properties: {
@@ -125,6 +130,10 @@ export const addTaskCommentDefinition = {
       comment: {
         type: 'string',
         description: 'Comment content (required). Supports HTML formatting and @mentions (e.g. @Jarrod Lawson). Tags: <div>, <p>, <strong>, <em>, <ul>, <li>, <a href="">.',
+      },
+      hidden: {
+        type: 'boolean',
+        description: 'When true, posts a hidden (internal) comment that is not visible to clients in the client portal. Defaults to false. Note: hidden comments are not available in internal projects.',
       },
     },
     required: ['task_id', 'comment'],


### PR DESCRIPTION
## Summary

Closes #20.

Adds the ability to post a **hidden (internal) comment** on a task — a comment visible to team members but not to clients in the client portal.

Rather than introduce a separate tool, this extends the existing `add_task_comment` tool with an optional `hidden` boolean (KISS — one tool for posting task comments). When `hidden` is omitted, the attribute is left off the request payload entirely, so existing behavior is unchanged (Productive defaults to not hidden).

## Changes

- **`src/api/types.ts`** — add optional `hidden?: boolean` to `ProductiveCommentCreate` attributes.
- **`src/tools/comments.ts`** — accept `hidden` in the Zod schema, pass it through to `createComment` (only when provided), surface the hidden state in the result text, and document it in the tool definition.
- **`src/tools/__tests__/comments.test.ts`** (new) — tests covering `hidden: true`, `hidden: false`, omitted, correct task linkage, and rejection of non-boolean values.
- **`README.md`** — document the new `hidden` parameter.

## Notes / caveats

- Hidden comments are **not available in internal projects** (Productive API limitation) — documented in the tool description.
- After merging, the running MCP server must be **restarted** to pick up the rebuilt `build/index.js` and expose the new parameter.

## Verification

- `npm run build` — passes (zero TS errors)
- `npm test` — 62/62 tests pass (5 new)
- **Live API test** against the Jarrod test project (task 17076340): posting with `hidden: true` returned `hidden: true` on read-back; omitting `hidden` defaulted to `hidden: false`. Both test comments were deleted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
