### PR TITLE
fix: guard against null comment bodies in list_comments

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -311,7 +311,8 @@ export interface ProductiveComment {
   id: string;
   type: 'comments';
   attributes: {
-    body: string;
+    /** Comment body HTML; null for body-less comments (e.g. attachment-only or system-generated). */
+    body: string | null;
     commentable_type: string;
     created_at: string;
     updated_at: string;

--- a/src/tools/__tests__/comments.test.ts
+++ b/src/tools/__tests__/comments.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { addTaskCommentTool } from '../comments.js';
+import { addTaskCommentTool, listCommentsTool } from '../comments.js';
 import { ProductiveAPIClient } from '../../api/client.js';
 import { ProductiveComment, ProductiveCommentCreate } from '../../api/types.js';
 
@@ -105,5 +105,38 @@ describe('addTaskCommentTool - hidden parameter', () => {
         hidden: 'yes',
       })
     ).rejects.toThrow(/Invalid parameters/);
+  });
+});
+
+/**
+ * Builds a comment resource for list responses, allowing a null body
+ * (the API returns null for attachment-only or system-generated comments).
+ */
+function makeListedComment(id: string, body: string | null): ProductiveComment {
+  return {
+    id,
+    type: 'comments',
+    attributes: {
+      body,
+      commentable_type: 'task',
+      created_at: '2026-06-10T10:00:00Z',
+      updated_at: '2026-06-10T10:00:00Z',
+    },
+  };
+}
+
+describe('listCommentsTool - null comment bodies', () => {
+  it('renders comments with a null body as (no content) instead of throwing', async () => {
+    const listComments = vi.fn().mockResolvedValue({
+      data: [makeListedComment('1', 'A real comment'), makeListedComment('2', null)],
+    });
+    const client = { listComments } as unknown as ProductiveAPIClient;
+
+    const result = await listCommentsTool(client, { task_id: '18263163' });
+
+    const text = result.content[0].text;
+    expect(text).toContain('Comments (2)');
+    expect(text).toContain('A real comment');
+    expect(text).toContain('(no content)');
   });
 });

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -15,7 +15,8 @@ function resolvePersonName(personId: string | undefined, included?: ProductiveIn
   return `${first} ${last}`.trim() || undefined;
 }
 
-function truncateBody(body: string, maxLength = 200): string {
+function truncateBody(body: string | null | undefined, maxLength = 200): string {
+  if (!body) return '(no content)';
   if (body.length <= maxLength) return body;
   return body.substring(0, maxLength) + '...';
 }
@@ -238,7 +239,7 @@ export async function getCommentTool(
     const creatorName = resolvePersonName(creatorId, included) || `Person ${creatorId || 'unknown'}`;
 
     let text = `Comment ID: ${comment.id}\n`;
-    text += `Body: ${attrs.body}\n`;
+    text += `Body: ${attrs.body ?? '(no content)'}\n`;
     text += `Commentable Type: ${attrs.commentable_type}\n`;
     text += `Creator: ${creatorName}\n`;
     text += `Created: ${attrs.created_at}\n`;


### PR DESCRIPTION
## Summary

Fixes #22 — `list_comments` crashed with `MCP error -32603: Cannot read properties of null (reading 'length')` whenever a task's comment thread contained a comment with a `null` body (e.g. attachment-only, system-generated, or draft entries).

## Changes

- `truncateBody` in `src/tools/comments.ts` now accepts `string | null | undefined` and renders `(no content)` for empty bodies — this was the only unguarded `.length` in the list-comments path
- `ProductiveComment.attributes.body` typed as `string | null` in `src/api/types.ts` to match what the API actually returns
- `get_comment` renders `(no content)` instead of printing the word "null" for body-less comments
- Regression test covering a thread containing a null-body comment

## Verification

- `npx tsc` compiles with zero errors
- All 64 tests pass (`npm test`), including the new null-body regression test
- Verified end-to-end against the live API: a task thread that previously reproduced the crash now returns all comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
