### PR TITLE
chore: sync package-lock to 1.1.3 and add list_comments verify script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "productive-mcp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "productive-mcp",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",

--- a/scripts/verify-list-comments.mjs
+++ b/scripts/verify-list-comments.mjs
@@ -1,0 +1,58 @@
+// One-off verification: spawn the built MCP server and call list_comments
+// for a task whose thread previously crashed with a null-body comment.
+// Usage: node scripts/verify-list-comments.mjs <task_id>
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const taskId = process.argv[2] ?? '18263163';
+const mcpConfig = JSON.parse(readFileSync(new URL('../.mcp.json', import.meta.url), 'utf8'));
+const { env } = mcpConfig.mcpServers.productive;
+
+const server = spawn('node', ['build/index.js'], {
+  env: { ...process.env, ...env },
+  stdio: ['pipe', 'pipe', 'inherit'],
+});
+
+let buffer = '';
+const pending = new Map();
+server.stdout.on('data', (chunk) => {
+  buffer += chunk.toString();
+  let idx;
+  while ((idx = buffer.indexOf('\n')) !== -1) {
+    const line = buffer.slice(0, idx).trim();
+    buffer = buffer.slice(idx + 1);
+    if (!line) continue;
+    const msg = JSON.parse(line);
+    if (msg.id !== undefined && pending.has(msg.id)) {
+      pending.get(msg.id)(msg);
+      pending.delete(msg.id);
+    }
+  }
+});
+
+function request(id, method, params) {
+  return new Promise((resolve) => {
+    pending.set(id, resolve);
+    server.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+  });
+}
+
+await request(1, 'initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'verify-script', version: '0.0.0' },
+});
+server.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+
+const result = await request(2, 'tools/call', {
+  name: 'list_comments',
+  arguments: { task_id: taskId },
+});
+
+if (result.error) {
+  console.error('TOOL ERROR:', JSON.stringify(result.error, null, 2));
+  process.exitCode = 1;
+} else {
+  console.log(result.result.content[0].text);
+}
+server.kill();


### PR DESCRIPTION
## Summary
- Sync `package-lock.json` to `1.1.3` to match the already-bumped `package.json`
- Add `scripts/verify-list-comments.mjs`, the one-off script used to verify the null-body comment fix in `list_comments` (commit c910e2f)

## Notes
The verify script spawns the built MCP server over stdio, runs the JSON-RPC handshake, and calls `list_comments` for a given task ID to confirm it no longer crashes on null comment bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)