### PR TITLE
feat: read & download attachments from comments and tasks

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -33,8 +33,14 @@ import {
   ProductivePageUpdate,
   ProductiveTaskDependency,
   ProductiveTaskDependencyCreate,
+  ProductiveAttachment,
   ProductiveError
 } from './types.js';
+
+/** Replaces any `token` query-parameter value with a redaction marker so secrets never reach logs. */
+function redactToken(text: string): string {
+  return text.replace(/([?&]token=)[^&\s]+/gi, '$1[REDACTED]');
+}
 
 export class ProductiveAPIClient {
   private config: Config;
@@ -65,8 +71,8 @@ export class ProductiveAPIClient {
 
       if (!response.ok) {
         const errorData = await response.json() as ProductiveError;
-        console.error('API Error Response:', JSON.stringify(errorData, null, 2));
-        console.error('Request was to:', url);
+        console.error('API Error Response:', redactToken(JSON.stringify(errorData, null, 2)));
+        console.error('Request was to:', redactToken(url));
         const errorMessage = errorData.errors?.[0]?.detail || `API request failed with status ${response.status}`;
         throw new Error(errorMessage);
       }
@@ -943,7 +949,7 @@ export class ProductiveAPIClient {
     page?: number;
   }): Promise<ProductiveResponse<ProductiveComment>> {
     const q = new URLSearchParams();
-    q.append('include', 'creator');
+    q.append('include', 'creator,attachments');
     if (params?.task_id) q.append('filter[task_id]', params.task_id);
     if (params?.project_id) q.append('filter[project_id]', params.project_id);
     if (params?.discussion_id) q.append('filter[discussion_id]', params.discussion_id);
@@ -955,7 +961,7 @@ export class ProductiveAPIClient {
   }
 
   async getComment(commentId: string): Promise<ProductiveSingleResponse<ProductiveComment>> {
-    return this.makeRequest<ProductiveSingleResponse<ProductiveComment>>(`comments/${commentId}?include=creator`);
+    return this.makeRequest<ProductiveSingleResponse<ProductiveComment>>(`comments/${commentId}?include=creator,attachments`);
   }
 
   async updateComment(commentId: string, data: ProductiveCommentUpdate): Promise<ProductiveSingleResponse<ProductiveComment>> {
@@ -1125,5 +1131,63 @@ export class ProductiveAPIClient {
 
   async deleteTaskDependency(dependencyId: string): Promise<void> {
     return this.makeVoidRequest(`task_dependencies/${dependencyId}`, { method: 'DELETE' });
+  }
+
+  // ---- Attachment methods ----
+
+  /**
+   * Fetch a single attachment resource (metadata only — name, content_type, size, url).
+   *
+   * @param attachmentId - The ID of the attachment to retrieve
+   * @returns Promise resolving to the attachment resource
+   */
+  async getAttachment(attachmentId: string): Promise<ProductiveSingleResponse<ProductiveAttachment>> {
+    return this.makeRequest<ProductiveSingleResponse<ProductiveAttachment>>(`attachments/${attachmentId}`);
+  }
+
+  /**
+   * Download an attachment's bytes server-side.
+   *
+   * The API token is injected into the file URL as a `token` query parameter
+   * (the documented method — see https://developer.productive.io/working_with_attachments.html)
+   * and NEVER returned to the caller. Only the decoded bytes and metadata leave this method.
+   *
+   * @param attachmentId - The ID of the attachment to download
+   * @returns The file bytes plus name, content type and size
+   */
+  async downloadAttachment(attachmentId: string): Promise<{
+    name: string;
+    contentType: string;
+    size: number;
+    data: Buffer;
+  }> {
+    const res = await this.getAttachment(attachmentId);
+    const attrs = res.data.attributes;
+    const url = attrs.url;
+
+    if (!url) {
+      throw new Error(`Attachment ${attachmentId} has no downloadable URL.`);
+    }
+
+    const separator = url.includes('?') ? '&' : '?';
+    const downloadUrl = `${url}${separator}token=${this.config.PRODUCTIVE_API_TOKEN}`;
+
+    const response = await fetch(downloadUrl, { redirect: 'follow' });
+
+    if (!response.ok) {
+      // Deliberately omit the URL from the error so the token cannot leak into logs.
+      throw new Error(
+        `Failed to download attachment ${attachmentId}: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+
+    return {
+      name: attrs.name,
+      contentType: attrs.content_type,
+      size: attrs.size,
+      data: Buffer.from(arrayBuffer),
+    };
   }
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -67,8 +67,45 @@ export interface ProductiveTask {
         type: 'people';
       };
     };
+    attachments?: {
+      data: Array<{
+        id: string;
+        type: 'attachments';
+      }>;
+    };
     [key: string]: any;
   };
+}
+
+/**
+ * A Productive attachment resource. Polymorphic — attaches to a task, comment,
+ * invoice, etc. (see `attachable_type`). The `url` requires the API token as a
+ * `token` query parameter to download; `temp_url` is an internal storage path
+ * and is NOT directly downloadable.
+ */
+export interface ProductiveAttachment {
+  id: string;
+  type: 'attachments';
+  attributes: {
+    /** Original filename, e.g. "report.pdf". */
+    name: string;
+    /** MIME type, e.g. "application/pdf". */
+    content_type: string;
+    /** File size in bytes. */
+    size: number;
+    /** Authenticated download URL (requires `?token=<API_TOKEN>`). */
+    url: string;
+    /** Internal storage path — NOT directly downloadable. */
+    temp_url?: string;
+    /** Thumbnail URL for images, otherwise null. */
+    thumb?: string | null;
+    /** Parent resource kind: "task" | "comment" | "invoice" | ... */
+    attachable_type?: string;
+    created_at?: string;
+    deleted_at?: string | null;
+    [key: string]: any;
+  };
+  relationships?: Record<string, any>;
 }
 
 export interface ProductiveIncludedResource {
@@ -337,6 +374,12 @@ export interface ProductiveComment {
         id: string;
         type: 'tasks';
       };
+    };
+    attachments?: {
+      data: Array<{
+        id: string;
+        type: 'attachments';
+      }>;
     };
     [key: string]: any;
   };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,7 @@
 import { config } from 'dotenv';
 import { z } from 'zod';
+import os from 'os';
+import path from 'path';
 
 // Silence dotenv output to stdout (MCP requires clean stdout)
 const originalWrite = process.stdout.write;
@@ -16,6 +18,11 @@ const configSchema = z.object({
   PRODUCTIVE_ORG_ID: z.string().min(1, 'Organization ID is required'),
   PRODUCTIVE_USER_ID: z.string().optional(),
   PRODUCTIVE_API_BASE_URL: z.string().url().default('https://api.productive.io/api/v2/'),
+  /** Directory where downloaded attachments are cached. Defaults to an OS-temp subdirectory. */
+  PRODUCTIVE_ATTACHMENT_DIR: z
+    .string()
+    .min(1)
+    .default(path.join(os.tmpdir(), 'productive-mcp-attachments')),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import { listTodosTool, listTodosDefinition, getTodoTool, getTodoDefinition, cre
 import { listPagesTool, listPagesDefinition, getPageTool, getPageDefinition, createPageTool, createPageDefinition, updatePageTool, updatePageDefinition, deletePageTool, deletePageDefinition, movePageTool, movePageDefinition, copyPageTool, copyPageDefinition } from './tools/pages.js';
 import { listPeopleTool, listPeopleDefinition, getPersonTool, getPersonDefinition } from './tools/people.js';
 import { listTaskDependenciesTool, listTaskDependenciesDefinition, getTaskDependencyTool, getTaskDependencyDefinition, createTaskDependencyTool, createTaskDependencyDefinition, deleteTaskDependencyTool, deleteTaskDependencyDefinition } from './tools/task-dependencies.js';
+import { getAttachmentTool, getAttachmentDefinition } from './tools/attachments.js';
 
 export async function createServer() {
   // Initialize API client and config early to check user context
@@ -129,6 +130,8 @@ export async function createServer() {
       getTaskDependencyDefinition,
       createTaskDependencyDefinition,
       deleteTaskDependencyDefinition,
+      // Attachments
+      getAttachmentDefinition,
     ],
   }));
   
@@ -329,6 +332,10 @@ export async function createServer() {
         return await createTaskDependencyTool(apiClient, args);
       case 'delete_task_dependency':
         return await deleteTaskDependencyTool(apiClient, args);
+
+      // Attachments
+      case 'get_attachment':
+        return await getAttachmentTool(apiClient, args);
 
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/src/tools/__tests__/attachments.test.ts
+++ b/src/tools/__tests__/attachments.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @fileoverview Tests for the get_attachment tool and client download mechanism.
+ * @module tools/__tests__/attachments.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the filesystem so tests never touch disk.
+const mkdir = vi.fn().mockResolvedValue(undefined);
+const writeFile = vi.fn().mockResolvedValue(undefined);
+vi.mock('fs', () => ({
+  promises: {
+    mkdir: (...args: unknown[]) => mkdir(...args),
+    writeFile: (...args: unknown[]) => writeFile(...args),
+  },
+}));
+
+// Mock config so the cache dir is deterministic and no env validation runs.
+vi.mock('../../config/index.js', () => ({
+  getConfig: () => ({
+    PRODUCTIVE_API_TOKEN: 'secret-token',
+    PRODUCTIVE_ORG_ID: '1',
+    PRODUCTIVE_API_BASE_URL: 'https://api.test/',
+    PRODUCTIVE_ATTACHMENT_DIR: '/cache',
+  }),
+}));
+
+import { getAttachmentTool } from '../attachments.js';
+import { ProductiveAPIClient } from '../../api/client.js';
+import { Config } from '../../config/index.js';
+
+beforeEach(() => {
+  mkdir.mockClear();
+  writeFile.mockClear();
+});
+
+function mockClient(file: { name: string; contentType: string; size: number; data: Buffer }) {
+  const downloadAttachment = vi.fn().mockResolvedValue(file);
+  const client = { downloadAttachment } as unknown as ProductiveAPIClient;
+  return { client, downloadAttachment };
+}
+
+describe('getAttachmentTool', () => {
+  it('downloads, saves to the cache dir, and returns the path for a PDF', async () => {
+    const { client, downloadAttachment } = mockClient({
+      name: 'report.pdf',
+      contentType: 'application/pdf',
+      size: 1234,
+      data: Buffer.from('%PDF-1.4 fake'),
+    });
+
+    const result = await getAttachmentTool(client, { attachment_id: '8779248' });
+
+    expect(downloadAttachment).toHaveBeenCalledWith('8779248');
+    expect(mkdir).toHaveBeenCalledWith('/cache', { recursive: true });
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    const text = result.content[0] as { type: string; text: string };
+    expect(text.text).toContain('report.pdf');
+    expect(text.text).toContain('application/pdf');
+    expect(text.text).toContain('1234 bytes');
+    expect(text.text).toContain('8779248-report.pdf');
+    // PDF is not an image -> no inline image block.
+    expect(result.content).toHaveLength(1);
+  });
+
+  it('returns an inline image block for image content types', async () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const { client } = mockClient({
+      name: 'image.png',
+      contentType: 'image/png',
+      size: bytes.length,
+      data: bytes,
+    });
+
+    const result = await getAttachmentTool(client, { attachment_id: '8779231' });
+
+    expect(result.content).toHaveLength(2);
+    const image = result.content[1] as { type: string; data: string; mimeType: string };
+    expect(image.type).toBe('image');
+    expect(image.mimeType).toBe('image/png');
+    expect(image.data).toBe(bytes.toString('base64'));
+  });
+
+  it('sanitizes unsafe characters in the filename', async () => {
+    const { client } = mockClient({
+      name: 'my report (final).xlsx',
+      contentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      size: 10,
+      data: Buffer.from('PK'),
+    });
+
+    await getAttachmentTool(client, { attachment_id: '55' });
+
+    const savedPath = writeFile.mock.calls[0][0] as string;
+    expect(savedPath).not.toContain(' ');
+    expect(savedPath).not.toContain('(');
+    expect(savedPath).toContain('55-my_report__final_.xlsx');
+  });
+
+  it('rejects a missing attachment_id', async () => {
+    const { client } = mockClient({ name: 'x', contentType: 'text/plain', size: 1, data: Buffer.from('x') });
+    await expect(getAttachmentTool(client, {})).rejects.toThrow(/Invalid parameters/);
+    await expect(getAttachmentTool(client, { attachment_id: '' })).rejects.toThrow(
+      /Attachment ID is required/
+    );
+  });
+});
+
+describe('ProductiveAPIClient.downloadAttachment', () => {
+  const config = {
+    PRODUCTIVE_API_TOKEN: 'secret-token',
+    PRODUCTIVE_ORG_ID: '1',
+    PRODUCTIVE_API_BASE_URL: 'https://api.test/',
+    PRODUCTIVE_ATTACHMENT_DIR: '/cache',
+  } as Config;
+
+  it('appends the token to the file url and returns decoded bytes', async () => {
+    const meta = {
+      data: {
+        id: '8779248',
+        type: 'attachments',
+        attributes: {
+          name: 'report.pdf',
+          content_type: 'application/pdf',
+          size: 5,
+          url: 'https://files.productive.io/attachments/files/008/779/248/original/report.pdf?1781846698',
+        },
+      },
+    };
+    const fileBytes = new Uint8Array([1, 2, 3, 4, 5]);
+
+    const fetchMock = vi
+      .fn()
+      // 1st call: getAttachment metadata
+      .mockResolvedValueOnce({ ok: true, json: async () => meta })
+      // 2nd call: file download
+      .mockResolvedValueOnce({ ok: true, arrayBuffer: async () => fileBytes.buffer });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new ProductiveAPIClient(config);
+    const file = await client.downloadAttachment('8779248');
+
+    // Token appended with '&' because the url already has a query string.
+    const downloadUrl = fetchMock.mock.calls[1][0] as string;
+    expect(downloadUrl).toContain('?1781846698&token=secret-token');
+    expect(file.name).toBe('report.pdf');
+    expect(file.contentType).toBe('application/pdf');
+    expect(Array.from(file.data)).toEqual([1, 2, 3, 4, 5]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('throws without leaking the token when the download fails', async () => {
+    const meta = {
+      data: {
+        id: '99',
+        type: 'attachments',
+        attributes: {
+          name: 'x.pdf',
+          content_type: 'application/pdf',
+          size: 1,
+          url: 'https://files.productive.io/attachments/files/x.pdf?1',
+        },
+      },
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => meta })
+      .mockResolvedValueOnce({ ok: false, status: 403, statusText: 'Forbidden' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new ProductiveAPIClient(config);
+
+    let message = '';
+    try {
+      await client.downloadAttachment('99');
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(message).toMatch(/Failed to download attachment 99: 403 Forbidden/);
+    expect(message).not.toContain('secret-token');
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/tools/__tests__/comments.test.ts
+++ b/src/tools/__tests__/comments.test.ts
@@ -140,3 +140,48 @@ describe('listCommentsTool - null comment bodies', () => {
     expect(text).toContain('(no content)');
   });
 });
+
+describe('listCommentsTool - attachments', () => {
+  it('renders attachment metadata (id, name, type, size) without exposing a URL or token', async () => {
+    const comment: ProductiveComment = {
+      id: '5',
+      type: 'comments',
+      attributes: {
+        body: null,
+        commentable_type: 'task',
+        created_at: '2026-06-10T10:00:00Z',
+        updated_at: '2026-06-10T10:00:00Z',
+      },
+      relationships: {
+        attachments: { data: [{ id: '8779231', type: 'attachments' }] },
+      },
+    };
+    const listComments = vi.fn().mockResolvedValue({
+      data: [comment],
+      included: [
+        {
+          id: '8779231',
+          type: 'attachments',
+          attributes: {
+            name: 'image.png',
+            content_type: 'image/png',
+            size: 7035,
+            url: 'https://files.productive.io/attachments/files/008/779/231/original/image.png?1781846603',
+          },
+        },
+      ],
+    });
+    const client = { listComments } as unknown as ProductiveAPIClient;
+
+    const result = await listCommentsTool(client, { task_id: '18263163' });
+
+    const text = result.content[0].text;
+    expect(text).toContain('Attachments (1)');
+    expect(text).toContain('ID 8779231');
+    expect(text).toContain('image.png');
+    expect(text).toContain('image/png');
+    expect(text).toContain('7035 bytes');
+    expect(text).not.toContain('files.productive.io');
+    expect(text).not.toContain('token');
+  });
+});

--- a/src/tools/attachments.ts
+++ b/src/tools/attachments.ts
@@ -1,0 +1,112 @@
+/**
+ * @fileoverview Tool for downloading Productive attachments so Claude can process them.
+ * @module tools/attachments
+ */
+
+import { z } from 'zod';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { ProductiveAPIClient } from '../api/client.js';
+import { getConfig } from '../config/index.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+
+type ToolContent =
+  | { type: 'text'; text: string }
+  | { type: 'image'; data: string; mimeType: string };
+
+type ToolResult = { content: ToolContent[] };
+
+const getAttachmentSchema = z.object({
+  attachment_id: z.string().min(1, 'Attachment ID is required'),
+});
+
+/**
+ * Make a filename safe for the local filesystem by replacing any character that
+ * is not alphanumeric, dot, underscore or hyphen.
+ */
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+/**
+ * Download a Productive attachment by ID, save it to the local cache directory,
+ * and return its path. For images, the bytes are also returned inline as an MCP
+ * `image` content block so hosts without filesystem access can view them.
+ *
+ * Attachments may live on a task or a comment; fetch the parent with `get_task` /
+ * `get_comment` (or `list_comments`) to discover attachment IDs first.
+ *
+ * @param client - The Productive API client
+ * @param args - Tool arguments validated against {@link getAttachmentSchema}
+ * @returns A text block with the saved path and metadata, plus an inline image block for image types
+ */
+export async function getAttachmentTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<ToolResult> {
+  try {
+    const params = getAttachmentSchema.parse(args);
+
+    const file = await client.downloadAttachment(params.attachment_id);
+
+    const config = getConfig();
+    const dir = config.PRODUCTIVE_ATTACHMENT_DIR;
+    await fs.mkdir(dir, { recursive: true });
+
+    const safeName = sanitizeFilename(file.name || `attachment-${params.attachment_id}`);
+    const filePath = path.join(dir, `${params.attachment_id}-${safeName}`);
+    await fs.writeFile(filePath, file.data);
+
+    const content: ToolContent[] = [
+      {
+        type: 'text',
+        text:
+          `Attachment downloaded.\n` +
+          `Name: ${file.name}\n` +
+          `Type: ${file.contentType}\n` +
+          `Size: ${file.size} bytes\n` +
+          `Saved to: ${filePath}`,
+      },
+    ];
+
+    if (file.contentType?.startsWith('image/')) {
+      content.push({
+        type: 'image',
+        data: file.data.toString('base64'),
+        mimeType: file.contentType,
+      });
+    }
+
+    return { content };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map((e) => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export const getAttachmentDefinition = {
+  name: 'get_attachment',
+  description:
+    'Download an attachment from Productive.io by its ID so it can be processed (PDF, Excel, image, or any file type). ' +
+    'The file is saved to a local cache directory and the path is returned; images are also returned inline. ' +
+    'Find attachment IDs via get_task, get_comment, or list_comments (attachments are listed with their IDs).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      attachment_id: {
+        type: 'string',
+        description: 'The ID of the attachment to download (required)',
+      },
+    },
+    required: ['attachment_id'],
+  },
+};

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -3,6 +3,7 @@ import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { ProductiveIncludedResource } from '../api/types.js';
 import { resolveMentions, MentionResolutionResult } from '../utils/mentions.js';
+import { formatAttachments } from '../utils/attachments.js';
 
 type ToolResult = { content: Array<{ type: string; text: string }> };
 
@@ -173,8 +174,9 @@ export async function listCommentsTool(
       const creatorName = resolvePersonName(creatorId, response.included) || `Person ${creatorId || 'unknown'}`;
       const pinned = comment.attributes.pinned_at ? ' [PINNED]' : '';
       const body = truncateBody(comment.attributes.body);
+      const attachments = formatAttachments(comment.relationships, response.included, '  ');
 
-      return `- Comment ID: ${comment.id}${pinned}\n  By: ${creatorName}\n  Date: ${comment.attributes.created_at}\n  Body: ${body}`;
+      return `- Comment ID: ${comment.id}${pinned}\n  By: ${creatorName}\n  Date: ${comment.attributes.created_at}\n  Body: ${body}${attachments}`;
     }).join('\n\n');
 
     return {
@@ -251,6 +253,7 @@ export async function getCommentTool(
     text += `Pinned: ${attrs.pinned_at ? `Yes (${attrs.pinned_at})` : 'No'}\n`;
     if (attrs.reactions) text += `Reactions: ${JSON.stringify(attrs.reactions)}\n`;
     if (attrs.version_number !== undefined) text += `Version: ${attrs.version_number}\n`;
+    text += formatAttachments(comment.relationships, included, '');
 
     return {
       content: [{ type: 'text', text }],

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { ProductiveTaskUpdate, ProductiveIncludedResource } from '../api/types.js';
+import { formatAttachments } from '../utils/attachments.js';
 
 function resolvePersonName(personId: string | undefined, included?: ProductiveIncludedResource[]): string | undefined {
   if (!personId || !included) return undefined;
@@ -171,7 +172,7 @@ export async function getTaskTool(
     const config = await import('../config/index.js').then(m => m.getConfig());
     
     // Create URL with task_list included
-    const url = `${config.PRODUCTIVE_API_BASE_URL}tasks/${params.task_id}?include=task_list,assignee,workflow_status`;
+    const url = `${config.PRODUCTIVE_API_BASE_URL}tasks/${params.task_id}?include=task_list,assignee,workflow_status,attachments`;
     
     // Create request with proper headers from config
     const response = await fetch(url, {
@@ -269,9 +270,8 @@ export async function getTaskTool(
     // Include task list ID information if available
     if (taskListId) {
       text += `Task List ID: ${taskListId}\n`;
-      
+
     // If there's included data for the task list, include the name
-    console.log('Included data:', JSON.stringify(data.included));
     if (data.included && Array.isArray(data.included)) {
       const taskList = data.included.find((item: any) => item.type === 'task_lists' && item.id === taskListId);
       if (taskList) {
@@ -279,7 +279,9 @@ export async function getTaskTool(
       }
     }
     }
-    
+
+    text += formatAttachments(task.relationships, data.included, '');
+
     return {
       content: [{
         type: 'text',

--- a/src/utils/__tests__/attachments.test.ts
+++ b/src/utils/__tests__/attachments.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Tests for the shared attachment formatter.
+ * @module utils/__tests__/attachments.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatAttachments } from '../attachments.js';
+import { ProductiveIncludedResource } from '../../api/types.js';
+
+const included: ProductiveIncludedResource[] = [
+  {
+    id: '8779248',
+    type: 'attachments',
+    attributes: {
+      name: 'This_is_a_pdf_attachment.pdf',
+      content_type: 'application/pdf',
+      size: 16165,
+      url: 'https://files.productive.io/attachments/files/008/779/248/original/This_is_a_pdf_attachment.pdf?1781846698',
+    },
+  },
+];
+
+describe('formatAttachments', () => {
+  it('returns an empty string when there are no attachments', () => {
+    expect(formatAttachments({}, included)).toBe('');
+    expect(formatAttachments({ attachments: { data: [] } }, included)).toBe('');
+    expect(formatAttachments(undefined, included)).toBe('');
+  });
+
+  it('renders id, name, content type and size from the included resource', () => {
+    const rels = { attachments: { data: [{ id: '8779248', type: 'attachments' }] } };
+    const out = formatAttachments(rels, included);
+
+    expect(out).toContain('Attachments (1)');
+    expect(out).toContain('ID 8779248');
+    expect(out).toContain('This_is_a_pdf_attachment.pdf');
+    expect(out).toContain('application/pdf');
+    expect(out).toContain('16165 bytes');
+  });
+
+  it('never renders the download URL or a token', () => {
+    const rels = { attachments: { data: [{ id: '8779248', type: 'attachments' }] } };
+    const out = formatAttachments(rels, included);
+
+    expect(out).not.toContain('files.productive.io');
+    expect(out).not.toContain('token');
+    expect(out).not.toContain('http');
+  });
+
+  it('falls back to the bare ID when the attachment is missing from included', () => {
+    const rels = { attachments: { data: [{ id: '999', type: 'attachments' }] } };
+    const out = formatAttachments(rels, included);
+
+    expect(out).toContain('ID 999');
+    expect(out).not.toContain('undefined');
+  });
+
+  it('applies the indent to each line', () => {
+    const rels = { attachments: { data: [{ id: '8779248', type: 'attachments' }] } };
+    const out = formatAttachments(rels, included, '  ');
+
+    expect(out).toContain('\n  - ID 8779248');
+  });
+});

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Shared rendering for attachment metadata on comments and tasks.
+ * @module utils/attachments
+ */
+
+import { ProductiveIncludedResource } from '../api/types.js';
+
+interface AttachmentRef {
+  id: string;
+  type: string;
+}
+
+interface AttachmentRelationships {
+  attachments?: {
+    data?: AttachmentRef[] | null;
+  };
+}
+
+/**
+ * Render a human-readable list of attachments for a comment or task.
+ *
+ * Resolves each attachment reference against the JSON:API `included` array to
+ * show filename, content type and size. The download URL is deliberately NOT
+ * rendered — it requires a secret token; callers should use the `get_attachment`
+ * tool with the attachment ID to download bytes server-side.
+ *
+ * @param relationships - The resource's relationships object (may contain `attachments`)
+ * @param included - The JSON:API `included` array from the response
+ * @param indent - Leading whitespace applied to each line
+ * @returns A formatted block (leading newline included), or an empty string when there are no attachments
+ */
+export function formatAttachments(
+  relationships: AttachmentRelationships | undefined,
+  included: ProductiveIncludedResource[] | undefined,
+  indent = ''
+): string {
+  const refs = relationships?.attachments?.data;
+  if (!refs || refs.length === 0) {
+    return '';
+  }
+
+  const lines = refs.map((ref) => {
+    const att = included?.find((item) => item.type === 'attachments' && item.id === ref.id);
+    if (!att) {
+      return `${indent}- ID ${ref.id}`;
+    }
+    const a = att.attributes;
+    const size = typeof a.size === 'number' ? `${a.size} bytes` : 'unknown size';
+    const name = a.name ?? 'unnamed';
+    const contentType = a.content_type ?? 'unknown type';
+    return `${indent}- ID ${ref.id}: ${name} (${contentType}, ${size})`;
+  });
+
+  return `\n${indent}Attachments (${refs.length}) — use get_attachment with the ID to download:\n${lines.join('\n')}`;
+}


### PR DESCRIPTION
Closes #26.

Lets the MCP server read and download attachments (PDF, Excel, image, anything) that live on a **task** or a **comment**, so Claude can process them.

## Phase 1 — Discovery
- New `ProductiveAttachment` type; `attachments` relationship added to `ProductiveComment` and `ProductiveTask`.
- `include=attachments` added to `list_comments`, `get_comment`, and `get_task`.
- Shared `formatAttachments` helper renders each attachment's **id, name, content type, size** on comments and tasks — no URL/token shown, just a pointer to use `get_attachment`.

## Phase 2 — `get_attachment` download tool
- Auto-downloads the file to a local cache dir (`PRODUCTIVE_ATTACHMENT_DIR`, defaults to an OS-temp subdir) and returns the path.
- Images are **also** returned inline as an MCP `image` block, so hosts without filesystem access (e.g. Claude Desktop) can view them.

## Security — token never leaves the server
The `?token=` query param is the officially documented download method ([docs](https://developer.productive.io/working_with_attachments.html)), but it is confined to the server process:
- Discovery output contains no URL or token.
- The tokenized URL is built inside `client.downloadAttachment()` and is never part of any tool result.
- `redactToken()` scrubs `token=` from error logs; download errors omit the URL entirely.

## Drive-by fix
Removed a stray `console.log` in `get_task` that dumped `included` JSON to **stdout** — that corrupts the stdio MCP protocol channel, and adding `attachments` to the same `include` made it dump even more.

## Verification
- 88 unit tests pass (`vitest run`); `tsc --noEmit` clean.
- Live smoke test against the three test-project fixtures:

| Fixture | Result |
|---|---|
| `8779231` png | 7035 bytes, magic ✓, inline image ✓, no token leak |
| `8779248` pdf | 16165 bytes, magic ✓, path only, no token leak |
| `8779254` xlsx | 8853 bytes, `PK` magic ✓, path only, no token leak |

`get_task` confirmed rendering attachment metadata live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
