### PR TITLE
fix: surface JSON:API error diagnostics (source.pointer) from API failures

### DIFF
--- a/src/api/__tests__/client-errors.test.ts
+++ b/src/api/__tests__/client-errors.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview Tests that Productive API errors surface JSON:API diagnostics
+ *               (title, status, source.pointer) instead of being discarded.
+ * @module api/__tests__/client-errors.test
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ProductiveAPIClient, ProductiveApiError } from '../client.js';
+import { Config } from '../../config/index.js';
+
+const config = {
+  PRODUCTIVE_API_TOKEN: 'secret-token',
+  PRODUCTIVE_ORG_ID: '1',
+  PRODUCTIVE_API_BASE_URL: 'https://api.test/',
+  PRODUCTIVE_ATTACHMENT_DIR: '/cache',
+} as Config;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ProductiveAPIClient error surfacing', () => {
+  it('surfaces title, status and source.pointer from a 422 (makeRequest path)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          errors: [
+            {
+              status: '422',
+              title: 'Invalid attribute',
+              detail: 'attribute is invalid',
+              source: { pointer: '/data/attributes/date' },
+            },
+          ],
+        }),
+      })
+    );
+
+    const client = new ProductiveAPIClient(config);
+
+    let caught: unknown;
+    try {
+      await client.getTask('123');
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ProductiveApiError);
+    const err = caught as ProductiveApiError;
+    expect(err.httpStatus).toBe(422);
+    expect(err.message).toContain('Invalid attribute');
+    expect(err.message).toContain('attribute is invalid');
+    expect(err.message).toContain('[at /data/attributes/date]');
+    expect(err.errors[0]?.source?.pointer).toBe('/data/attributes/date');
+  });
+
+  it('joins multiple errors into one message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          errors: [
+            { status: '422', title: 'Invalid attribute', detail: 'is invalid', source: { pointer: '/data/attributes/date' } },
+            { status: '422', title: 'Invalid relationship', detail: 'must exist', source: { pointer: '/data/relationships/task' } },
+          ],
+        }),
+      })
+    );
+
+    const client = new ProductiveAPIClient(config);
+    const err = (await client.getTask('123').catch((e) => e)) as ProductiveApiError;
+
+    expect(err.message).toContain('/data/attributes/date');
+    expect(err.message).toContain('/data/relationships/task');
+    expect(err.message).toContain(';');
+  });
+
+  it('falls back to the status when the body is not JSON', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => {
+          throw new Error('not json');
+        },
+      })
+    );
+
+    const client = new ProductiveAPIClient(config);
+    const err = (await client.getTask('123').catch((e) => e)) as ProductiveApiError;
+
+    expect(err).toBeInstanceOf(ProductiveApiError);
+    expect(err.httpStatus).toBe(500);
+    expect(err.message).toBe('API request failed with status 500');
+  });
+
+  it('also surfaces diagnostics from void requests (makeVoidRequest path)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: async () => ({
+          errors: [{ status: '422', title: 'Invalid', detail: 'nope', source: { pointer: '/data/attributes/board_id' } }],
+        }),
+      })
+    );
+
+    const client = new ProductiveAPIClient(config);
+    const err = (await client.archiveTaskList('5').catch((e) => e)) as ProductiveApiError;
+
+    expect(err).toBeInstanceOf(ProductiveApiError);
+    expect(err.httpStatus).toBe(422);
+    expect(err.message).toContain('[at /data/attributes/board_id]');
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -42,6 +42,50 @@ function redactToken(text: string): string {
   return text.replace(/([?&]token=)[^&\s]+/gi, '$1[REDACTED]');
 }
 
+/**
+ * Error thrown when the Productive API returns a non-2xx response.
+ *
+ * Preserves the HTTP status and the structured JSON:API `errors` array so
+ * callers can branch on them (e.g. map a 422 to an invalid-params error),
+ * while `message` carries a human-readable, self-diagnosing summary that
+ * includes each error's `title`, `status` and `source.pointer`.
+ */
+export class ProductiveApiError extends Error {
+  /** HTTP status code of the failed response. */
+  readonly httpStatus: number;
+  /** The JSON:API `errors` array from the response body (empty if none/unparseable). */
+  readonly errors: ProductiveError['errors'];
+
+  constructor(message: string, httpStatus: number, errors: ProductiveError['errors']) {
+    super(message);
+    this.name = 'ProductiveApiError';
+    this.httpStatus = httpStatus;
+    this.errors = errors;
+  }
+}
+
+/**
+ * Build a human-readable message from a Productive JSON:API error body,
+ * surfacing `title`, `status` and `source.pointer`/`parameter` for each error
+ * (the `pointer` is the field that says which attribute Productive rejected).
+ */
+function formatProductiveError(errorData: ProductiveError | undefined, httpStatus: number): string {
+  const errs = errorData?.errors;
+  if (!errs || errs.length === 0) {
+    return `API request failed with status ${httpStatus}`;
+  }
+  return errs
+    .map((e) => {
+      const title = e.title || 'API error';
+      const code = e.status || String(httpStatus);
+      const detail = e.detail ? `: ${e.detail}` : '';
+      const pointer = e.source?.pointer ? ` [at ${e.source.pointer}]` : '';
+      const parameter = e.source?.parameter ? ` [param ${e.source.parameter}]` : '';
+      return `${title} (${code})${detail}${pointer}${parameter}`;
+    })
+    .join('; ');
+}
+
 export class ProductiveAPIClient {
   private config: Config;
   
@@ -70,11 +114,14 @@ export class ProductiveAPIClient {
       });
 
       if (!response.ok) {
-        const errorData = await response.json() as ProductiveError;
-        console.error('API Error Response:', redactToken(JSON.stringify(errorData, null, 2)));
+        const errorData = await response.json().catch(() => undefined) as ProductiveError | undefined;
+        console.error('API Error Response:', redactToken(JSON.stringify(errorData ?? {}, null, 2)));
         console.error('Request was to:', redactToken(url));
-        const errorMessage = errorData.errors?.[0]?.detail || `API request failed with status ${response.status}`;
-        throw new Error(errorMessage);
+        throw new ProductiveApiError(
+          formatProductiveError(errorData, response.status),
+          response.status,
+          errorData?.errors ?? []
+        );
       }
 
       return await response.json() as T;
@@ -98,12 +145,12 @@ export class ProductiveAPIClient {
     });
 
     if (!response.ok) {
-      let errorMessage = `API request failed with status ${response.status}`;
-      try {
-        const errorData = await response.json() as ProductiveError;
-        errorMessage = errorData.errors?.[0]?.detail || errorMessage;
-      } catch { /* no JSON body */ }
-      throw new Error(errorMessage);
+      const errorData = await response.json().catch(() => undefined) as ProductiveError | undefined;
+      throw new ProductiveApiError(
+        formatProductiveError(errorData, response.status),
+        response.status,
+        errorData?.errors ?? []
+      );
     }
   }
   

--- a/src/tools/__tests__/time-entries-errors.test.ts
+++ b/src/tools/__tests__/time-entries-errors.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Tests that create_time_entry maps Productive 422s to InvalidParams
+ *               with the self-diagnosing message, and leaves other errors as InternalError.
+ * @module tools/__tests__/time-entries-errors.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { createTimeEntryTool } from '../time-entries.js';
+import { ProductiveAPIClient, ProductiveApiError } from '../../api/client.js';
+
+const validArgs = {
+  date: '2026-06-20',
+  time: '30m',
+  person_id: '698785',
+  service_id: '456',
+  task_id: '789',
+  note: 'Worked on the attachment download feature',
+  confirm: true,
+};
+
+function clientThatThrows(error: Error): ProductiveAPIClient {
+  return { createTimeEntry: vi.fn().mockRejectedValue(error) } as unknown as ProductiveAPIClient;
+}
+
+describe('createTimeEntryTool - error mapping', () => {
+  it('maps a 422 to InvalidParams and keeps the source.pointer in the message', async () => {
+    const apiError = new ProductiveApiError(
+      'Invalid attribute (422): attribute is invalid [at /data/attributes/date]',
+      422,
+      [{ status: '422', title: 'Invalid attribute', detail: 'attribute is invalid', source: { pointer: '/data/attributes/date' } }]
+    );
+    const client = clientThatThrows(apiError);
+
+    let caught: any;
+    try {
+      await createTimeEntryTool(client, validArgs);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe(ErrorCode.InvalidParams);
+    expect(caught.message).toContain('/data/attributes/date');
+    expect(caught.message).toContain('attribute is invalid');
+  });
+
+  it('leaves a non-422 API error as InternalError', async () => {
+    const apiError = new ProductiveApiError('API request failed with status 500', 500, []);
+    const client = clientThatThrows(apiError);
+
+    let caught: any;
+    try {
+      await createTimeEntryTool(client, validArgs);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught.code).toBe(ErrorCode.InternalError);
+    expect(caught.message).toContain('500');
+  });
+});

--- a/src/tools/time-entries.ts
+++ b/src/tools/time-entries.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { ProductiveAPIClient } from '../api/client.js';
+import { ProductiveAPIClient, ProductiveApiError } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { ProductiveTimeEntryCreate } from '../api/types.js';
 
@@ -376,7 +376,14 @@ ID: ${response.data.id}`;
         `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
       );
     }
-    
+
+    // A 422 from Productive is a data/validation error (e.g. locked timesheet
+    // period, or a task/service not in an open budget) — surface it as invalid
+    // params with the self-diagnosing message (includes the source.pointer).
+    if (error instanceof ProductiveApiError && error.httpStatus === 422) {
+      throw new McpError(ErrorCode.InvalidParams, error.message);
+    }
+
     throw new McpError(
       ErrorCode.InternalError,
       error instanceof Error ? error.message : 'Unknown error occurred'


### PR DESCRIPTION
Closes #25.

`create_time_entry` (and every other write) surfaced Productive 422s as an opaque `-32603: attribute is invalid` — `makeRequest` kept only `errors[0].detail` and threw the rest away, so the JSON:API `source.pointer` (the one field that says *which* attribute failed) was only visible in server stderr, never to the caller.

## Changes

**Global (both request paths):** `makeRequest` and `makeVoidRequest` now throw a new `ProductiveApiError` carrying:
- `httpStatus` — the HTTP status code
- `errors` — the full JSON:API `errors[]` array
- a self-diagnosing `message` built from each error's `title`, `status`, `detail`, and `source.pointer`/`parameter`, e.g.

  ```
  Invalid attribute (422): attribute is invalid [at /data/attributes/date]
  ```

  Multiple errors are joined; a non-JSON body falls back to `API request failed with status <n>`.

**Targeted:** `create_time_entry` remaps 422s to `InvalidParams` instead of `InternalError`, since a 422 is a data/validation error (locked timesheet period, or a task/service not in an open budget the person belongs to) — not a server fault.

## Why this fixes the intermittent mystery

The reporter's "same service, some succeed some fail" symptom is exactly what a `source.pointer` disambiguates:
- `/data/attributes/date` → entry date falls in a locked/approved period
- `/data/relationships/task` or `/service` → task/service not in an open budget the person is a member of

## Verification
- `tsc --noEmit` clean; 94 unit tests pass (`vitest run`), incl. new coverage for: pointer surfacing, multi-error joining, non-JSON body fallback, the void-request path, and the 422→InvalidParams mapping (plus non-422 staying InternalError).
- Live error-path check against the real API (bogus GET, no side effects): now returns `ProductiveApiError` `Record Not Found (404): The requested record was not found` with the structured `errors` preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
