### PR TITLE
feat: add get_task_overview for single-call task briefings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An MCP (Model Context Protocol) server that enables Claude Desktop, Claude Code,
 
 ## Features
 
+- **Task Briefing**: `get_task_overview` returns everything about one task in a single call, so reading an issue does not cost a dozen round trips
 - **Companies & Projects**: List companies and projects with status filtering
 - **Folders**: Full CRUD with archive/restore for organizing project content
 - **Task Lists**: Full lifecycle management — create, update, archive/restore, copy, move, reposition
@@ -193,6 +194,33 @@ Restart Claude Code after configuration.
 
 ## Available Tools
 
+### Reading a task you have been given the ID for
+
+Use `get_task_overview` first. It answers "what is this issue about" in one call:
+
+```
+get_task_overview(task_id: "19300600")
+```
+
+It returns metadata (status, assignee, project, task list, dates, estimate vs worked time),
+the full original description, then the 10 most recent comments with their complete bodies in
+chronological order. HTML is rendered to plain text and stored `@mention` blobs are collapsed
+to names, so the thread reads as prose.
+
+Attachments are surfaced two ways, because most of them are screenshots that carry the
+context you need:
+
+- **Inline**, at the exact point in the comment where the screenshot was posted, as
+  `[attachment 9131629: Screenshot_2026-07-31_110620.png]`.
+- **Indexed**, in an `ATTACHMENTS` block at the end listing every attachment on the task and
+  on the comments shown, flagged `[IMAGE]`, with the source comment and author.
+
+Then fetch only the ones that matter with `get_attachment(attachment_id: "9131629")`, which
+returns images inline.
+
+The older path (`get_task`, then `list_comments`, then a `get_comment` per truncated comment)
+still works, but costs one round trip per comment and truncates bodies to 200 characters.
+
 ### User & Context Tools
 
 | Tool | Description |
@@ -237,9 +265,10 @@ Restart Claude Code after configuration.
 
 | Tool | Description |
 |------|-------------|
+| `get_task_overview` | **Start here for any task ID.** One call returns metadata, the full description, the most recent comments in full (default 10, `comment_limit` up to 50) oldest-first, and an index of every attachment on the task and those comments. Requires `task_id` |
 | `list_tasks` | List tasks. Filter by `project_id`, `assignee_id`, `status` (open/closed), `limit` |
 | `get_project_tasks` | Get all tasks for a project. Requires `project_id`, optional `status` |
-| `get_task` | Get task details by `task_id` |
+| `get_task` | Get task details by `task_id`. Metadata only, no comments. Prefer `get_task_overview` |
 | `create_task` | Create a task. Requires `title`. Optional `project_id`, `board_id`, `task_list_id`, `assignee_id` ("me" supported), `due_date`, `status` |
 | `update_task_assignment` | Assign/unassign a task. Requires `task_id`, `assignee_id` ("me" or "null" supported) |
 | `update_task_details` | Update title/description. Requires `task_id`, optional `title`, `description`, `description_html` |
@@ -272,7 +301,7 @@ Restart Claude Code after configuration.
 | Tool | Description |
 |------|-------------|
 | `add_task_comment` | Add a comment to a task. Requires `task_id`, `comment` (supports HTML and @mentions). Optional `hidden` (boolean) posts an internal comment not visible to clients in the client portal |
-| `list_comments` | List comments. Filter by `task_id`, `project_id`, `limit` |
+| `list_comments` | List comments. Filter by `task_id`, `project_id`, `limit`. Bodies are truncated to 200 chars; to read a task's thread use `get_task_overview` instead |
 | `get_comment` | Get full comment details by `comment_id` |
 | `update_comment` | Edit a comment. Requires `comment_id`, `body` |
 | `delete_comment` | Delete a comment by `comment_id` |

--- a/scripts/probe-task-overview.mjs
+++ b/scripts/probe-task-overview.mjs
@@ -1,0 +1,23 @@
+/**
+ * Manual probe: run get_task_overview against the live Productive API.
+ * Usage: node scripts/probe-task-overview.mjs <task_id> [comment_limit]
+ */
+import { getTaskOverviewTool } from '../build/tools/task-overview.js';
+import { ProductiveAPIClient } from '../build/api/client.js';
+import { getConfig } from '../build/config/index.js';
+
+const [taskId, commentLimit] = process.argv.slice(2);
+if (!taskId) {
+  console.error('Usage: node scripts/probe-task-overview.mjs <task_id> [comment_limit]');
+  process.exit(1);
+}
+
+const client = new ProductiveAPIClient(getConfig());
+const result = await getTaskOverviewTool(client, {
+  task_id: taskId,
+  ...(commentLimit ? { comment_limit: Number(commentLimit) } : {}),
+});
+
+const text = result.content[0].text;
+console.log(text);
+console.error(`\n[probe] ${text.length} chars, roughly ${Math.round(text.length / 4)} tokens`);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -367,8 +367,16 @@ export class ProductiveAPIClient {
     return this.makeRequest<ProductiveSingleResponse<ProductivePerson>>(`people/${personId}`);
   }
 
-  async getTask(taskId: string): Promise<ProductiveSingleResponse<ProductiveTask>> {
-    return this.makeRequest<ProductiveSingleResponse<ProductiveTask>>(`tasks/${taskId}`);
+  /**
+   * Fetch a single task.
+   *
+   * @param taskId - The task ID
+   * @param include - Optional JSON:API `include` list, e.g. `assignee,workflow_status,attachments`.
+   *                  Included resources arrive in the response's `included` array.
+   */
+  async getTask(taskId: string, include?: string): Promise<ProductiveSingleResponse<ProductiveTask>> {
+    const qs = include ? `?include=${encodeURIComponent(include)}` : '';
+    return this.makeRequest<ProductiveSingleResponse<ProductiveTask>>(`tasks/${encodeURIComponent(taskId)}${qs}`);
   }
 
   async updateTask(taskId: string, taskData: ProductiveTaskUpdate): Promise<ProductiveSingleResponse<ProductiveTask>> {
@@ -992,6 +1000,8 @@ export class ProductiveAPIClient {
     project_id?: string;
     discussion_id?: string;
     page_id?: string;
+    /** JSON:API sort expression, e.g. `-created_at` for newest first. */
+    sort?: string;
     limit?: number;
     page?: number;
   }): Promise<ProductiveResponse<ProductiveComment>> {
@@ -1001,6 +1011,7 @@ export class ProductiveAPIClient {
     if (params?.project_id) q.append('filter[project_id]', params.project_id);
     if (params?.discussion_id) q.append('filter[discussion_id]', params.discussion_id);
     if (params?.page_id) q.append('filter[page_id]', params.page_id);
+    if (params?.sort) q.append('sort', params.sort);
     if (params?.limit) q.append('page[size]', params.limit.toString());
     if (params?.page) q.append('page[number]', params.page.toString());
     const qs = q.toString();

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import { listPagesTool, listPagesDefinition, getPageTool, getPageDefinition, cre
 import { listPeopleTool, listPeopleDefinition, getPersonTool, getPersonDefinition } from './tools/people.js';
 import { listTaskDependenciesTool, listTaskDependenciesDefinition, getTaskDependencyTool, getTaskDependencyDefinition, createTaskDependencyTool, createTaskDependencyDefinition, deleteTaskDependencyTool, deleteTaskDependencyDefinition } from './tools/task-dependencies.js';
 import { getAttachmentTool, getAttachmentDefinition } from './tools/attachments.js';
+import { getTaskOverviewTool, getTaskOverviewDefinition } from './tools/task-overview.js';
 
 export async function createServer() {
   // Initialize API client and config early to check user context
@@ -69,6 +70,7 @@ export async function createServer() {
       repositionTaskListDefinition,
       listTasksDefinition,
       getProjectTasksDefinition,
+      getTaskOverviewDefinition,
       getTaskDefinition,
       createTaskDefinition,
       updateTaskAssignmentDefinition,
@@ -156,6 +158,9 @@ export async function createServer() {
         
       case 'get_task':
         return await getTaskTool(apiClient, args);
+
+      case 'get_task_overview':
+        return await getTaskOverviewTool(apiClient, args);
         
       case 'my_tasks':
         return await myTasksTool(apiClient, config, args);

--- a/src/tools/__tests__/task-overview.test.ts
+++ b/src/tools/__tests__/task-overview.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @fileoverview Tests for the get_task_overview single-call briefing tool.
+ * @module tools/__tests__/task-overview.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { getTaskOverviewTool } from '../task-overview.js';
+import { ProductiveAPIClient } from '../../api/client.js';
+
+interface StubOptions {
+  taskAttributes?: Record<string, unknown>;
+  taskRelationships?: Record<string, unknown>;
+  taskIncluded?: Array<Record<string, unknown>>;
+  comments?: Array<Record<string, unknown>>;
+  commentsIncluded?: Array<Record<string, unknown>>;
+  totalComments?: number;
+}
+
+/** Build a client stub whose two calls mirror the JSON:API shapes Productive returns. */
+function makeClient(options: StubOptions = {}) {
+  const getTask = vi.fn().mockResolvedValue({
+    data: {
+      id: '555',
+      type: 'tasks',
+      attributes: {
+        title: 'Renewal email not sending',
+        description: '<p>Members report no renewal email.</p>',
+        created_at: '2026-08-01T09:00:00+10:00',
+        closed: false,
+        ...options.taskAttributes,
+      },
+      relationships: {
+        assignee: { data: { id: '10', type: 'people' } },
+        ...options.taskRelationships,
+      },
+    },
+    included: options.taskIncluded ?? [
+      { id: '10', type: 'people', attributes: { first_name: 'Jay', last_name: 'McCormack' } },
+    ],
+  });
+
+  const listComments = vi.fn().mockResolvedValue({
+    data: options.comments ?? [],
+    included: options.commentsIncluded ?? [],
+    meta: { total_count: options.totalComments ?? (options.comments?.length ?? 0) },
+  });
+
+  return { getTask, listComments } as unknown as ProductiveAPIClient & {
+    getTask: ReturnType<typeof vi.fn>;
+    listComments: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeComment(
+  id: string,
+  body: string | null,
+  createdAt: string,
+  extras: Record<string, unknown> = {}
+) {
+  return {
+    id,
+    type: 'comments',
+    attributes: { body, created_at: createdAt, commentable_type: 'task', updated_at: createdAt },
+    relationships: { creator: { data: { id: '10', type: 'people' } } },
+    ...extras,
+  };
+}
+
+async function runTool(client: ProductiveAPIClient, args: unknown): Promise<string> {
+  const result = await getTaskOverviewTool(client, args);
+  return result.content[0].text;
+}
+
+describe('getTaskOverviewTool', () => {
+  it('fetches the task and its comments in exactly two calls', async () => {
+    const client = makeClient();
+    await runTool(client, { task_id: '555' });
+
+    expect(client.getTask).toHaveBeenCalledTimes(1);
+    expect(client.listComments).toHaveBeenCalledTimes(1);
+  });
+
+  it('requests the most recent comments newest-first so the newest are kept', async () => {
+    const client = makeClient();
+    await runTool(client, { task_id: '555', comment_limit: 25 });
+
+    expect(client.listComments).toHaveBeenCalledWith({
+      task_id: '555',
+      sort: '-created_at',
+      limit: 25,
+    });
+  });
+
+  it('defaults to the ten most recent comments', async () => {
+    const client = makeClient();
+    await runTool(client, { task_id: '555' });
+
+    expect(client.listComments).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 10 })
+    );
+  });
+
+  it('reverses the API order so comments read oldest to newest', async () => {
+    const client = makeClient({
+      comments: [
+        makeComment('3', '<p>newest</p>', '2026-08-03T09:00:00+10:00'),
+        makeComment('2', '<p>middle</p>', '2026-08-02T09:00:00+10:00'),
+        makeComment('1', '<p>oldest</p>', '2026-08-01T09:00:00+10:00'),
+      ],
+    });
+
+    const text = await runTool(client, { task_id: '555' });
+
+    expect(text.indexOf('oldest')).toBeLessThan(text.indexOf('middle'));
+    expect(text.indexOf('middle')).toBeLessThan(text.indexOf('newest'));
+    expect(text).toContain('[1]');
+    expect(text).toContain('[3]');
+  });
+
+  it('returns comment bodies in full without truncation', async () => {
+    const longBody = 'y'.repeat(3000);
+    const client = makeClient({
+      comments: [makeComment('1', `<p>${longBody}</p>`, '2026-08-01T09:00:00+10:00')],
+    });
+
+    const text = await runTool(client, { task_id: '555' });
+
+    expect(text).toContain(longBody);
+    expect(text).not.toContain('...');
+  });
+
+  it('renders stored mention blobs as readable names', async () => {
+    const blob =
+      '@[{"type":"person","id":"705374","label":"Julian Smith","avatar_url":null,"attachment_url":null,"is_done":false}]';
+    const client = makeClient({
+      comments: [makeComment('1', `<p>${blob} please review</p>`, '2026-08-01T09:00:00+10:00')],
+    });
+
+    const text = await runTool(client, { task_id: '555' });
+
+    expect(text).toContain('@Julian Smith please review');
+    expect(text).not.toContain('avatar_url');
+  });
+
+  it('indexes attachments from both the task and its comments with image flags', async () => {
+    const client = makeClient({
+      taskRelationships: {
+        assignee: { data: { id: '10', type: 'people' } },
+        attachments: { data: [{ id: '900', type: 'attachments' }] },
+      },
+      taskIncluded: [
+        { id: '10', type: 'people', attributes: { first_name: 'Jay', last_name: 'McCormack' } },
+        {
+          id: '900',
+          type: 'attachments',
+          attributes: { name: 'spec.pdf', content_type: 'application/pdf', size: 2048 },
+        },
+      ],
+      comments: [
+        makeComment('1', '<p>see screenshot</p>', '2026-08-02T09:00:00+10:00', {
+          relationships: {
+            creator: { data: { id: '10', type: 'people' } },
+            attachments: { data: [{ id: '901', type: 'attachments' }] },
+          },
+        }),
+      ],
+      commentsIncluded: [
+        { id: '10', type: 'people', attributes: { first_name: 'Jay', last_name: 'McCormack' } },
+        {
+          id: '901',
+          type: 'attachments',
+          attributes: { name: 'error.png', content_type: 'image/png', size: 4096 },
+        },
+      ],
+    });
+
+    const text = await runTool(client, { task_id: '555' });
+
+    expect(text).toContain('spec.pdf');
+    expect(text).toContain('error.png');
+    expect(text).toContain('[IMAGE]');
+    expect(text).toContain('2 attachments, 1 of them image');
+    expect(text).toContain('get_attachment');
+    expect(text).toContain('on the task itself');
+    expect(text).toContain('on comment 1');
+  });
+
+  it('reports when no attachments are present', async () => {
+    const client = makeClient({
+      comments: [makeComment('1', '<p>no files here</p>', '2026-08-01T09:00:00+10:00')],
+    });
+
+    const text = await runTool(client, { task_id: '555' });
+
+    expect(text).toContain('None on this task or in the comments shown');
+  });
+
+  it('flags hidden and pinned comments', async () => {
+    const client = makeClient({
+      comments: [
+        makeComment('1', '<p>internal note</p>', '2026-08-01T09:00:00+10:00', {
+          attributes: {
+            body: '<p>internal note</p>',
+            created_at: '2026-08-01T09:00:00+10:00',
+            commentable_type: 'task',
+            updated_at: '2026-08-01T09:00:00+10:00',
+            hidden: true,
+            pinned_at: '2026-08-01T10:00:00+10:00',
+          },
+        }),
+      ],
+    });
+
+    const text = await runTool(client, { task_id: '555' });
+
+    expect(text).toContain('[PINNED]');
+    expect(text).toContain('[INTERNAL - not client visible]');
+  });
+
+  it('handles attachment-only comments that have a null body', async () => {
+    const client = makeClient({
+      comments: [makeComment('1', null, '2026-08-01T09:00:00+10:00')],
+    });
+
+    const text = await runTool(client, { task_id: '555' });
+
+    expect(text).toContain('attachment-only or system-generated');
+  });
+
+  it('says how many comments exist when more than the limit were returned', async () => {
+    const client = makeClient({
+      comments: [makeComment('1', '<p>only one shown</p>', '2026-08-01T09:00:00+10:00')],
+      totalComments: 34,
+    });
+
+    const text = await runTool(client, { task_id: '555' });
+
+    expect(text).toContain('showing the 1 most recent of 34');
+  });
+
+  it('states plainly when a task has no comments', async () => {
+    const client = makeClient();
+    const text = await runTool(client, { task_id: '555' });
+
+    expect(text).toContain('No comments on this task');
+  });
+
+  it('includes headline metadata and the full description', async () => {
+    const client = makeClient({
+      taskAttributes: { task_number: 342, due_date: '2026-08-20', worked_time: 120 },
+      taskRelationships: {
+        assignee: { data: { id: '10', type: 'people' } },
+        workflow_status: { data: { id: '77', type: 'workflow_statuses' } },
+        project: { data: { id: '88', type: 'projects' } },
+      },
+      taskIncluded: [
+        { id: '10', type: 'people', attributes: { first_name: 'Jay', last_name: 'McCormack' } },
+        { id: '77', type: 'workflow_statuses', attributes: { name: 'In Progress' } },
+        { id: '88', type: 'projects', attributes: { name: 'LNP Hub' } },
+      ],
+    });
+
+    const text = await runTool(client, { task_id: '555' });
+
+    expect(text).toContain('TASK 555: Renewal email not sending');
+    expect(text).toContain('Status: In Progress');
+    expect(text).toContain('Assignee: Jay McCormack (ID: 10)');
+    expect(text).toContain('Project: LNP Hub (ID: 88)');
+    expect(text).toContain('Task number: 342');
+    expect(text).toContain('Due: 2026-08-20');
+    expect(text).toContain('Members report no renewal email.');
+  });
+
+  it('rejects a missing task_id with an invalid-params error', async () => {
+    const client = makeClient();
+    await expect(getTaskOverviewTool(client, {})).rejects.toThrow(/Invalid parameters/);
+    await expect(getTaskOverviewTool(client, { task_id: '' })).rejects.toThrow(/Task ID is required/);
+  });
+
+  it('rejects a comment_limit above the supported maximum', async () => {
+    const client = makeClient();
+    await expect(
+      getTaskOverviewTool(client, { task_id: '555', comment_limit: 500 })
+    ).rejects.toThrow(/Invalid parameters/);
+  });
+});

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -199,7 +199,7 @@ export async function listCommentsTool(
 
 export const listCommentsDefinition = {
   name: 'list_comments',
-  description: 'List comments in Productive.io, optionally filtered by task or project.',
+  description: 'List comments in Productive.io, optionally filtered by task or project. Bodies are truncated to 200 characters here, so reading a task this way costs a follow-up get_comment per comment. To read a task\'s thread, use get_task_overview instead, which returns full comment bodies in one call.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/task-overview.ts
+++ b/src/tools/task-overview.ts
@@ -1,0 +1,315 @@
+/**
+ * @fileoverview Single-call briefing for a task: metadata, description, recent
+ * comments in full, and a consolidated attachment index.
+ * @module tools/task-overview
+ */
+
+import { z } from 'zod';
+import { ProductiveAPIClient } from '../api/client.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ProductiveComment, ProductiveIncludedResource } from '../api/types.js';
+import { htmlToText } from '../utils/html.js';
+import { renderStoredMentions } from '../utils/mentions.js';
+
+type ToolResult = { content: Array<{ type: string; text: string }> };
+
+/** An attachment discovered on the task or one of its comments. */
+interface AttachmentEntry {
+  id: string;
+  name: string;
+  contentType: string;
+  size: number | undefined;
+  isImage: boolean;
+  /** Where it hangs, e.g. "task" or "comment 900 by Sarah Lee, 2026-08-02". */
+  source: string;
+}
+
+const getTaskOverviewSchema = z.object({
+  task_id: z.string().min(1, 'Task ID is required'),
+  comment_limit: z.number().min(1).max(50).default(10).optional(),
+});
+
+const TASK_INCLUDES = 'assignee,creator,workflow_status,project,task_list,attachments';
+
+function findIncluded(
+  included: ProductiveIncludedResource[] | undefined,
+  type: string,
+  id: string | undefined
+): ProductiveIncludedResource | undefined {
+  if (!id || !included) return undefined;
+  return included.find((item) => item.type === type && item.id === id);
+}
+
+function personName(
+  included: ProductiveIncludedResource[] | undefined,
+  id: string | undefined
+): string | undefined {
+  const person = findIncluded(included, 'people', id);
+  if (!person) return undefined;
+  const full = `${person.attributes.first_name || ''} ${person.attributes.last_name || ''}`.trim();
+  return full || undefined;
+}
+
+/** Render "Name (ID: 123)", falling back to the bare ID, then to a placeholder. */
+function personLabel(
+  included: ProductiveIncludedResource[] | undefined,
+  id: string | undefined,
+  fallback: string
+): string {
+  if (!id) return fallback;
+  const name = personName(included, id);
+  return name ? `${name} (ID: ${id})` : `ID ${id}`;
+}
+
+/**
+ * Resolve an owner's `attachments` relationship into structured entries and
+ * append them to the running index.
+ */
+function collectAttachments(
+  relationships: Record<string, any> | undefined,
+  included: ProductiveIncludedResource[] | undefined,
+  source: string,
+  into: AttachmentEntry[]
+): AttachmentEntry[] {
+  const refs = relationships?.attachments?.data;
+  if (!Array.isArray(refs) || refs.length === 0) return [];
+
+  const entries = refs.map((ref: { id: string }) => {
+    const att = findIncluded(included, 'attachments', ref.id);
+    const attrs = att?.attributes ?? {};
+    const contentType: string = attrs.content_type ?? 'unknown type';
+    return {
+      id: ref.id,
+      name: attrs.name ?? 'unnamed',
+      contentType,
+      size: typeof attrs.size === 'number' ? attrs.size : undefined,
+      isImage: contentType.startsWith('image/'),
+      source,
+    };
+  });
+
+  into.push(...entries);
+  return entries;
+}
+
+function formatAttachmentLine(entry: AttachmentEntry, indent: string): string {
+  const size = entry.size !== undefined ? `, ${entry.size} bytes` : '';
+  const flag = entry.isImage ? ' [IMAGE - review this]' : '';
+  return `${indent}- attachment ${entry.id}: ${entry.name} (${entry.contentType}${size})${flag}`;
+}
+
+/** Comment bodies are HTML with embedded mention blobs; render both to plain text. */
+function renderBody(body: string | null | undefined): string {
+  return htmlToText(renderStoredMentions(body));
+}
+
+function buildHeader(
+  task: { id: string; attributes: Record<string, any>; relationships?: Record<string, any> },
+  included: ProductiveIncludedResource[] | undefined
+): string {
+  const a = task.attributes;
+  const rel = task.relationships;
+
+  const workflowStatus = findIncluded(included, 'workflow_statuses', rel?.workflow_status?.data?.id);
+  const status = workflowStatus?.attributes?.name || (a.closed ? 'closed' : 'open');
+  const project = findIncluded(included, 'projects', rel?.project?.data?.id);
+  const taskList = findIncluded(included, 'task_lists', rel?.task_list?.data?.id);
+
+  const lines = [
+    `TASK ${task.id}: ${a.title}`,
+    `Status: ${status} | Assignee: ${personLabel(included, rel?.assignee?.data?.id, 'Unassigned')}`,
+  ];
+
+  const placement: string[] = [];
+  if (project) placement.push(`Project: ${project.attributes.name} (ID: ${project.id})`);
+  if (taskList) placement.push(`Task list: ${taskList.attributes.name} (ID: ${taskList.id})`);
+  if (a.task_number) placement.push(`Task number: ${a.task_number}`);
+  if (placement.length > 0) lines.push(placement.join(' | '));
+
+  const dates: string[] = [];
+  dates.push(`Created: ${a.created_at || 'unknown'} by ${personLabel(included, rel?.creator?.data?.id, 'unknown')}`);
+  if (a.due_date) dates.push(`Due: ${a.due_date}`);
+  if (a.last_activity_at) dates.push(`Last activity: ${a.last_activity_at}`);
+  lines.push(dates.join(' | '));
+
+  const effort: string[] = [];
+  if (a.initial_estimate) effort.push(`Estimate: ${a.initial_estimate} min`);
+  if (a.worked_time) effort.push(`Worked: ${a.worked_time} min`);
+  if (a.private) effort.push('Private: yes');
+  if (effort.length > 0) lines.push(effort.join(' | '));
+
+  return lines.join('\n');
+}
+
+function buildCommentBlock(
+  comment: ProductiveComment,
+  position: number,
+  included: ProductiveIncludedResource[] | undefined,
+  attachmentIndex: AttachmentEntry[]
+): string {
+  const creatorId = comment.relationships?.creator?.data?.id;
+  const author = personName(included, creatorId) || `Person ${creatorId || 'unknown'}`;
+  const flags = [
+    comment.attributes.pinned_at ? '[PINNED]' : '',
+    comment.attributes.hidden ? '[INTERNAL - not client visible]' : '',
+    comment.attributes.edited_at ? '[EDITED]' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const header = `[${position}] ${comment.attributes.created_at} | ${author} | comment ${comment.id}${flags ? ` ${flags}` : ''}`;
+  const body = renderBody(comment.attributes.body) || '(no text; this comment is attachment-only or system-generated)';
+
+  const own = collectAttachments(
+    comment.relationships,
+    included,
+    `comment ${comment.id} by ${author}, ${comment.attributes.created_at}`,
+    attachmentIndex
+  );
+  const attachmentText =
+    own.length > 0
+      ? `\n  Attachments on this comment (${own.length}):\n${own.map((e) => formatAttachmentLine(e, '  ')).join('\n')}`
+      : '';
+
+  return `${header}\n${body}${attachmentText}`;
+}
+
+function buildAttachmentIndex(entries: AttachmentEntry[]): string {
+  if (entries.length === 0) {
+    return 'ATTACHMENTS\nNone on this task or in the comments shown.';
+  }
+
+  const imageCount = entries.filter((e) => e.isImage).length;
+  const summary =
+    `${entries.length} attachment${entries.length === 1 ? '' : 's'}` +
+    (imageCount > 0 ? `, ${imageCount} of them image${imageCount === 1 ? '' : 's'} (likely screenshots)` : '');
+
+  const lines = entries.map((e) => {
+    const size = e.size !== undefined ? `, ${e.size} bytes` : '';
+    const flag = e.isImage ? ' [IMAGE]' : '';
+    return `- ${e.id}: ${e.name} (${e.contentType}${size})${flag} | on ${e.source}`;
+  });
+
+  return (
+    `ATTACHMENTS\n${summary}.\n` +
+    `Call get_attachment with an ID below to download and view it. ` +
+    `Images are returned inline, so review any screenshot that the task or a comment refers to.\n` +
+    lines.join('\n')
+  );
+}
+
+/**
+ * Build a complete briefing for one task in a single tool call.
+ *
+ * Replaces the get_task then list_comments then get_comment round-trip loop:
+ * comment bodies are returned in full (never truncated), ordered oldest to
+ * newest so the thread reads as a narrative, and every attachment on the task
+ * or its comments is indexed with the ID needed to fetch it.
+ *
+ * @param client - The Productive API client
+ * @param args - Tool arguments validated against {@link getTaskOverviewSchema}
+ * @returns A single text block containing metadata, description, comments and attachment index
+ */
+export async function getTaskOverviewTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<ToolResult> {
+  try {
+    const params = getTaskOverviewSchema.parse(args);
+    const commentLimit = params.comment_limit ?? 10;
+
+    // One round trip each, in parallel, instead of a call per comment.
+    const [taskResponse, commentsResponse] = await Promise.all([
+      client.getTask(params.task_id, TASK_INCLUDES),
+      client.listComments({
+        task_id: params.task_id,
+        sort: '-created_at',
+        limit: commentLimit,
+      }),
+    ]);
+
+    const task = taskResponse.data;
+    const attachmentIndex: AttachmentEntry[] = [];
+
+    const sections: string[] = [buildHeader(task, taskResponse.included)];
+
+    const description = renderBody(task.attributes.description);
+    sections.push(`ORIGINAL TASK\n${description || '(no description)'}`);
+
+    const taskAttachments = collectAttachments(
+      task.relationships,
+      taskResponse.included,
+      'the task itself',
+      attachmentIndex
+    );
+    if (taskAttachments.length > 0) {
+      sections.push(
+        `Attachments on the task (${taskAttachments.length}):\n` +
+          taskAttachments.map((e) => formatAttachmentLine(e, '')).join('\n')
+      );
+    }
+
+    // The API returns newest first; reverse so the thread reads in order.
+    const comments = [...(commentsResponse.data ?? [])].reverse();
+    const totalComments = commentsResponse.meta?.total_count;
+
+    if (comments.length === 0) {
+      sections.push('COMMENTS\nNo comments on this task.');
+    } else {
+      const scope =
+        totalComments && totalComments > comments.length
+          ? `showing the ${comments.length} most recent of ${totalComments}, oldest first`
+          : `all ${comments.length}, oldest first`;
+      const blocks = comments.map((comment, index) =>
+        buildCommentBlock(comment, index + 1, commentsResponse.included, attachmentIndex)
+      );
+      sections.push(`COMMENTS (${scope})\n\n${blocks.join('\n\n')}`);
+    }
+
+    sections.push(buildAttachmentIndex(attachmentIndex));
+
+    return {
+      content: [{ type: 'text', text: sections.join('\n\n---\n\n') }],
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Invalid parameters: ${error.errors.map((e) => e.message).join(', ')}`
+      );
+    }
+
+    throw new McpError(
+      ErrorCode.InternalError,
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    );
+  }
+}
+
+export const getTaskOverviewDefinition = {
+  name: 'get_task_overview',
+  description:
+    'START HERE when given a Productive task/issue ID. Returns a complete briefing in ONE call: ' +
+    'task metadata (title, workflow status, assignee, project, task list, dates, estimate vs worked time), ' +
+    'the full original description, and the most recent comments with their FULL text in chronological order ' +
+    '(nothing is truncated). Every attachment on the task and on those comments is listed with its ID, flagged ' +
+    'when it is an image, so you can fetch just the screenshots that matter with get_attachment. ' +
+    'Use this instead of chaining get_task, list_comments and get_comment, which costs many round trips and truncates bodies.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      task_id: {
+        type: 'string',
+        description: 'The ID of the task to summarise (required)',
+      },
+      comment_limit: {
+        type: 'number',
+        description: 'How many of the most recent comments to return in full (1-50, default 10)',
+        minimum: 1,
+        maximum: 50,
+        default: 10,
+      },
+    },
+    required: ['task_id'],
+  },
+};

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -355,7 +355,7 @@ export const getProjectTasksDefinition = {
 
 export const getTaskDefinition = {
   name: 'get_task',
-  description: 'Get detailed information about a specific task by ID',
+  description: 'Get detailed information about a specific task by ID. Returns metadata only, with no comment history. To understand an issue you have been given the ID for, prefer get_task_overview, which returns this metadata plus the full recent comment thread and an attachment index in a single call.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/utils/__tests__/html.test.ts
+++ b/src/utils/__tests__/html.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Tests for the HTML to plain text converter.
+ * @module utils/__tests__/html.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { htmlToText } from '../html.js';
+
+describe('htmlToText', () => {
+  it('returns an empty string for null, undefined and empty input', () => {
+    expect(htmlToText(null)).toBe('');
+    expect(htmlToText(undefined)).toBe('');
+    expect(htmlToText('')).toBe('');
+  });
+
+  it('converts paragraphs into blank-line separated blocks', () => {
+    expect(htmlToText('<p>First para</p><p>Second para</p>')).toBe('First para\n\nSecond para');
+  });
+
+  it('converts list items into dashed bullets', () => {
+    expect(htmlToText('<ul><li>one</li><li>two</li></ul>')).toBe('- one\n- two');
+  });
+
+  it('keeps link destinations alongside the label', () => {
+    expect(htmlToText('<p>See <a href="https://example.com/x">the ticket</a>.</p>')).toBe(
+      'See the ticket (https://example.com/x).'
+    );
+  });
+
+  it('collapses a link whose label already is the URL', () => {
+    expect(htmlToText('<a href="https://example.com">https://example.com</a>')).toBe(
+      'https://example.com'
+    );
+  });
+
+  it('marks inline images so their presence survives', () => {
+    expect(htmlToText('<p>Before<img src="x.png">After</p>')).toBe('Before [inline image] After');
+  });
+
+  it('decodes named and numeric entities', () => {
+    expect(htmlToText('<p>a &amp; b &lt;c&gt; &#39;d&#39; &nbsp;e</p>')).toBe("a & b <c> 'd' e");
+  });
+
+  it('turns br tags into single newlines', () => {
+    expect(htmlToText('<p>line one<br>line two</p>')).toBe('line one\nline two');
+  });
+
+  it('strips script and style content entirely', () => {
+    expect(htmlToText('<p>keep</p><script>alert(1)</script>')).toBe('keep');
+  });
+
+  it('does not truncate long bodies', () => {
+    const long = 'x'.repeat(5000);
+    expect(htmlToText(`<p>${long}</p>`)).toHaveLength(5000);
+  });
+
+  it('collapses runs of blank lines left by nested block tags', () => {
+    expect(htmlToText('<div><p>a</p></div><div><p>b</p></div>')).toBe('a\n\nb');
+  });
+});

--- a/src/utils/__tests__/mentions.test.ts
+++ b/src/utils/__tests__/mentions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { extractMentionTokens, buildMentionReplacement, resolveMentions } from '../mentions.js';
+import { extractMentionTokens, buildMentionReplacement, resolveMentions, renderStoredMentions } from '../mentions.js';
 import { ProductivePerson } from '../../api/types.js';
 import { ProductiveAPIClient } from '../../api/client.js';
 
@@ -274,5 +274,39 @@ describe('resolveMentions', () => {
 
     expect(result.resolved).toHaveLength(1);
     expect(result.resolved[0].person.id).toBe('698785');
+  });
+});
+
+describe('renderStoredMentions', () => {
+  it('renders a person blob as an @Label mention', () => {
+    const body =
+      '<p>@[{"type":"person","id":"705374","label":"Julian Smith","avatar_url":null,"attachment_url":null,"is_done":false}] please review</p>';
+    expect(renderStoredMentions(body)).toBe('<p>@Julian Smith please review</p>');
+  });
+
+  it('renders an inline attachment blob as a pointer carrying the attachment ID', () => {
+    const body =
+      '<p>@[{"type":"inline_attachment","id":"9131629","label":"Screenshot.png","avatar_url":null,"attachment_url":"https://files.productive.io/x.png","is_done":false}]</p>';
+    expect(renderStoredMentions(body)).toBe('<p>[attachment 9131629: Screenshot.png]</p>');
+  });
+
+  it('renders several blobs of mixed type in one body', () => {
+    const body =
+      '@[{"type":"person","label":"Jay M"}] see @[{"type":"inline_attachment","id":"12","label":"err.png"}]';
+    expect(renderStoredMentions(body)).toBe('@Jay M see [attachment 12: err.png]');
+  });
+
+  it('leaves an unparseable blob verbatim', () => {
+    const body = '@[{not valid json}]';
+    expect(renderStoredMentions(body)).toBe('@[{not valid json}]');
+  });
+
+  it('returns an empty string for null and undefined', () => {
+    expect(renderStoredMentions(null)).toBe('');
+    expect(renderStoredMentions(undefined)).toBe('');
+  });
+
+  it('leaves text without blobs untouched', () => {
+    expect(renderStoredMentions('plain body @NotAMention')).toBe('plain body @NotAMention');
   });
 });

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Converts Productive's HTML rich-text bodies into readable plain text.
+ * @module utils/html
+ */
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+  hellip: '...',
+  mdash: '-',
+  ndash: '-',
+  rsquo: "'",
+  lsquo: "'",
+  rdquo: '"',
+  ldquo: '"',
+};
+
+/** Decode the HTML entities Productive actually emits, plus numeric escapes. */
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&#x([0-9a-f]+);/gi, (_m, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_m, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&([a-z]+);/gi, (match, name) => NAMED_ENTITIES[name.toLowerCase()] ?? match);
+}
+
+/**
+ * Convert an HTML comment or task description into plain text while keeping the
+ * structure that carries meaning: paragraph breaks, list bullets, and link URLs.
+ *
+ * Anchors become `text (url)` so a reviewer can still follow a link, and images
+ * become an `[inline image]` marker so their presence is visible even though the
+ * bytes live on an attachment record.
+ *
+ * @param html - Raw HTML from a Productive `body` or `description` attribute
+ * @returns Readable plain text, or an empty string when there is no content
+ */
+export function htmlToText(html: string | null | undefined): string {
+  if (!html) return '';
+
+  let text = html;
+
+  // Drop content that never renders as prose.
+  text = text.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, '');
+
+  // Anchors keep their destination: "label (https://...)".
+  text = text.replace(
+    /<a\b[^>]*?href\s*=\s*["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
+    (_match, href: string, label: string) => {
+      const cleanLabel = decodeEntities(label.replace(/<[^>]+>/g, '')).trim();
+      const cleanHref = decodeEntities(href).trim();
+      if (!cleanLabel) return cleanHref;
+      if (cleanLabel === cleanHref) return cleanHref;
+      return `${cleanLabel} (${cleanHref})`;
+    }
+  );
+
+  text = text.replace(/<img\b[^>]*>/gi, ' [inline image] ');
+  text = text.replace(/<br\s*\/?>/gi, '\n');
+  text = text.replace(/<\/(p|div|h[1-6]|tr|blockquote|pre)>/gi, '\n\n');
+  // The opening <li> supplies the line break, so closing it must not add another
+  // or every list ends up double spaced.
+  text = text.replace(/<li\b[^>]*>/gi, '\n- ');
+  text = text.replace(/<\/li>/gi, '');
+  text = text.replace(/<\/(ul|ol|table)>/gi, '\n');
+  text = text.replace(/<t[dh]\b[^>]*>/gi, ' | ');
+
+  // Anything left is presentational.
+  text = text.replace(/<[^>]+>/g, '');
+  text = decodeEntities(text);
+
+  // Tidy the whitespace the tag stripping leaves behind.
+  text = text.replace(/\r\n/g, '\n');
+  text = text
+    .split('\n')
+    .map((line) => line.replace(/[ \t]+/g, ' ').trimEnd())
+    .join('\n');
+  text = text.replace(/\n{3,}/g, '\n\n');
+
+  return text.trim();
+}

--- a/src/utils/mentions.ts
+++ b/src/utils/mentions.ts
@@ -46,6 +46,50 @@ export function extractMentionTokens(body: string): MentionToken[] {
   return tokens;
 }
 
+/**
+ * Matches a stored mention blob, e.g. `@[{"type":"person","label":"Jay M",...}]`.
+ * Kept deliberately tolerant so a malformed blob is left alone rather than mangled.
+ */
+const STORED_MENTION_REGEX = /@\[(\{[^\]]*\})\]/g;
+
+/**
+ * Render stored mention blobs back into readable text.
+ *
+ * Productive persists both people mentions and inline attachments as an inline
+ * JSON object. That is machine-readable but wastes a lot of tokens and is
+ * unreadable when a body is shown to a person, so collapse each blob:
+ *
+ * - `type: "person"` becomes `@Label`.
+ * - `type: "inline_attachment"` becomes a pointer carrying the attachment ID,
+ *   so a reader can see exactly where in the thread a screenshot sits and can
+ *   fetch it with `get_attachment` without hunting for the ID.
+ *
+ * Blobs that fail to parse are left verbatim.
+ *
+ * @param body - Comment or description text that may contain mention blobs
+ * @returns The same text with each blob rendered as readable text
+ */
+export function renderStoredMentions(body: string | null | undefined): string {
+  if (!body) return '';
+
+  return body.replace(STORED_MENTION_REGEX, (match, json: string) => {
+    try {
+      const parsed = JSON.parse(json) as { type?: string; id?: string; label?: string };
+      if (!parsed.label) return match;
+
+      if (parsed.type === 'inline_attachment') {
+        return parsed.id
+          ? `[attachment ${parsed.id}: ${parsed.label}]`
+          : `[attachment: ${parsed.label}]`;
+      }
+
+      return `@${parsed.label}`;
+    } catch {
+      return match;
+    }
+  });
+}
+
 export function buildMentionReplacement(person: ProductivePerson): string {
   const mention = {
     type: 'person',


### PR DESCRIPTION
## Problem

Reading a Productive issue currently costs **5 to 25 MCP round trips**. The sequence is `get_task`, then `list_comments`, which truncates every body to 200 characters, then a `get_comment` per comment to recover the text that was cut off. Screenshots, which usually carry the detail that matters, are invisible until several more calls in.

## What this adds

`get_task_overview(task_id, comment_limit?)` answers "what is this issue about" in **one call**. It fires two API requests in parallel and returns:

- **Metadata**: title, workflow status, assignee, project, task list, task number, created by/at, due date, last activity, estimate vs worked time
- **ORIGINAL TASK**: the full description, untruncated
- **COMMENTS**: the 10 most recent (configurable 1 to 50) with **complete bodies**, reversed into chronological order so the thread reads as a narrative, with `[PINNED]` / `[INTERNAL - not client visible]` / `[EDITED]` flags
- **ATTACHMENTS**: a consolidated index

### Attachments

Productive stores inline screenshots as `@[{"type":"inline_attachment","id":"9131629",...}]` blobs, so they are rendered as pointers **at the exact point in the sentence where they were posted**:

```
I completed the suspension and there is a completed task there

[attachment 9142835: Screenshot_2026-08-03_105042.png]

but when I go to the profile it still shows as an active - regular member

[attachment 9142850: Screenshot_2026-08-03_105149.png]
```

That gives positional context (which screenshot backs which claim), not just a bag of files. The closing index then lists everything with its source:

```
ATTACHMENTS
4 attachments, 4 of them images (likely screenshots).
Call get_attachment with an ID below to download and view it...
- 9131629: Screenshot_2026-07-31_110620.png (image/png, 9344 bytes) [IMAGE] | on comment 16692219 by Nick Frizzo, 2026-07-31T03:06:37
```

Only the relevant ones then need fetching via `get_attachment`. The index is honestly scoped ("in the comments shown"), so a narrow `comment_limit` cannot silently hide an older screenshot.

## Supporting changes

- **`src/utils/html.ts`** (new): renders HTML bodies to plain text, keeping paragraph breaks, list bullets, and link URLs as `label (url)`. This is where most of the token saving comes from.
- **`renderStoredMentions`**: collapses Productive's inline JSON mention blobs to `@Name` (they cost roughly 150 characters each) and `inline_attachment` blobs to ID-carrying pointers.
- **`listComments`** gains `sort`, so the request returns the *newest* comments rather than the oldest. Verified `sort=-created_at` against the live API.
- **`getTask`** gains an optional `include`, and now encodes its path segment.
- **Descriptions**: `get_task` and `list_comments` now name `get_task_overview` as the preferred path, and `list_comments` states that it truncates, so the model routes to the cheap tool.

## Verification

Run end to end over stdio against a real task (14 comments, 4 screenshots): **one call, roughly 2,700 tokens**, replacing the 5 to 25 calls it used to take. `tools/list` reports 72 tools with the new one registered.

Tests: **82 passing** (`npx vitest run --dir src`), type-check clean. 26 new tests cover call count, sort direction, chronological reversal, no truncation on a 3,000 character body, mention and inline-attachment rendering, image flagging, hidden/pinned flags, null bodies, and the "showing 10 of 34" count. Writing them caught a real bug where every rendered list came out double spaced.

Note: `npm test` reports 16 files because vitest also collects the compiled copies under `build/`. That is pre-existing and not addressed here; `npx vitest run --dir src` is the accurate figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)