### PR TITLE
fix: reference get_project_tasks, not a tool that does not exist

### DIFF
--- a/src/__tests__/tool-definitions.test.ts
+++ b/src/__tests__/tool-definitions.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Guards the advertised tool surface against self-inconsistency.
+ * @module __tests__/tool-definitions.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toolDefinitions } from '../server.js';
+
+const TOOL_NAMES = new Set(toolDefinitions.map((tool) => tool.name));
+
+/**
+ * Prefixes used by this server's tool names. A snake_case token starting with
+ * one of these inside a description is almost certainly meant to be a tool
+ * reference rather than prose.
+ */
+const TOOL_NAME_PREFIXES = [
+  'list_',
+  'get_',
+  'create_',
+  'update_',
+  'delete_',
+  'add_',
+  'move_',
+  'copy_',
+  'archive_',
+  'restore_',
+  'reposition_',
+  'pin_',
+  'unpin_',
+  'my_',
+];
+
+/** Every parameter name across every tool, so we do not mistake one for a tool. */
+const PARAMETER_NAMES = new Set(
+  toolDefinitions.flatMap((tool) =>
+    Object.keys((tool.inputSchema as { properties?: Record<string, unknown> }).properties ?? {})
+  )
+);
+
+/** Pull the snake_case tokens out of a tool definition that look like tool names. */
+function extractToolReferences(tool: (typeof toolDefinitions)[number]): string[] {
+  const blob = `${tool.description} ${JSON.stringify(tool.inputSchema)}`;
+  const tokens = blob.match(/\b[a-z]+(?:_[a-z]+)+\b/g) ?? [];
+  return [...new Set(tokens)].filter(
+    (token) => TOOL_NAME_PREFIXES.some((prefix) => token.startsWith(prefix)) && !PARAMETER_NAMES.has(token)
+  );
+}
+
+describe('tool definitions', () => {
+  it('advertises tools with unique names', () => {
+    expect(TOOL_NAMES.size).toBe(toolDefinitions.length);
+  });
+
+  it('gives every tool a name and a description', () => {
+    for (const tool of toolDefinitions) {
+      expect(tool.name, 'every tool needs a name').toBeTruthy();
+      expect(tool.description, `${tool.name} needs a description`).toBeTruthy();
+    }
+  });
+
+  it('never points at a tool that does not exist', () => {
+    const dangling: Array<{ tool: string; reference: string }> = [];
+
+    for (const tool of toolDefinitions) {
+      for (const reference of extractToolReferences(tool)) {
+        if (!TOOL_NAMES.has(reference)) {
+          dangling.push({ tool: tool.name, reference });
+        }
+      }
+    }
+
+    expect(dangling).toEqual([]);
+  });
+
+  it('describes the timesheet workflow using real tool names', () => {
+    const createTimeEntry = toolDefinitions.find((tool) => tool.name === 'create_time_entry');
+    expect(createTimeEntry).toBeDefined();
+    expect(createTimeEntry!.description).toContain('get_project_tasks');
+    expect(createTimeEntry!.description).not.toContain('list_project_tasks');
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,93 @@ import { listPeopleTool, listPeopleDefinition, getPersonTool, getPersonDefinitio
 import { listTaskDependenciesTool, listTaskDependenciesDefinition, getTaskDependencyTool, getTaskDependencyDefinition, createTaskDependencyTool, createTaskDependencyDefinition, deleteTaskDependencyTool, deleteTaskDependencyDefinition } from './tools/task-dependencies.js';
 import { getAttachmentTool, getAttachmentDefinition } from './tools/attachments.js';
 
+/**
+ * Every tool this server advertises, in the order clients see them.
+ *
+ * Exported so tests can assert on the surface without standing up a transport.
+ */
+export const toolDefinitions = [
+  whoAmITool,
+  listCompaniesDefinition,
+  listProjectsDefinition,
+  listBoardsTool,
+  createBoardTool,
+  listTaskListsTool,
+  createTaskListTool,
+  getTaskListDefinition,
+  updateTaskListDefinition,
+  archiveTaskListDefinition,
+  restoreTaskListDefinition,
+  copyTaskListDefinition,
+  moveTaskListDefinition,
+  repositionTaskListDefinition,
+  listTasksDefinition,
+  getProjectTasksDefinition,
+  getTaskDefinition,
+  createTaskDefinition,
+  updateTaskAssignmentDefinition,
+  updateTaskDetailsDefinition,
+  addTaskCommentDefinition,
+  updateTaskStatusDefinition,
+  listWorkflowStatusesDefinition,
+  myTasksDefinition,
+  listActivitiesTool,
+  getRecentUpdatesTool,
+  listTimeEntriesDefinition,
+  createTimeEntryDefinition,
+  listProjectDealsDefinition,
+  listDealServicesDefinition,
+  listServicesDefinition,
+  getProjectServicesDefinition,
+  updateTaskSprintTool,
+  moveTaskToListTool,
+  addToBacklogTool,
+  taskRepositionDefinition,
+  deleteTaskDefinition,
+  // Folders
+  listFoldersTool,
+  getFolderTool,
+  createFolderTool,
+  updateFolderTool,
+  archiveFolderTool,
+  restoreFolderTool,
+  // Subtasks
+  listSubtasksDefinition,
+  createSubtaskDefinition,
+  // Comments (expanded)
+  listCommentsDefinition,
+  getCommentDefinition,
+  updateCommentDefinition,
+  deleteCommentDefinition,
+  pinCommentDefinition,
+  unpinCommentDefinition,
+  addCommentReactionDefinition,
+  // Todos
+  listTodosDefinition,
+  getTodoDefinition,
+  createTodoDefinition,
+  updateTodoDefinition,
+  deleteTodoDefinition,
+  // Pages
+  listPagesDefinition,
+  getPageDefinition,
+  createPageDefinition,
+  updatePageDefinition,
+  deletePageDefinition,
+  movePageDefinition,
+  copyPageDefinition,
+  // People
+  listPeopleDefinition,
+  getPersonDefinition,
+  // Task Dependencies
+  listTaskDependenciesDefinition,
+  getTaskDependencyDefinition,
+  createTaskDependencyDefinition,
+  deleteTaskDependencyDefinition,
+  // Attachments
+  getAttachmentDefinition,
+];
+
 export async function createServer() {
   // Initialize API client and config early to check user context
   const config = getConfig();
@@ -52,87 +139,7 @@ export async function createServer() {
   
   // Register handlers
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: [
-      whoAmITool,
-      listCompaniesDefinition,
-      listProjectsDefinition,
-      listBoardsTool,
-      createBoardTool,
-      listTaskListsTool,
-      createTaskListTool,
-      getTaskListDefinition,
-      updateTaskListDefinition,
-      archiveTaskListDefinition,
-      restoreTaskListDefinition,
-      copyTaskListDefinition,
-      moveTaskListDefinition,
-      repositionTaskListDefinition,
-      listTasksDefinition,
-      getProjectTasksDefinition,
-      getTaskDefinition,
-      createTaskDefinition,
-      updateTaskAssignmentDefinition,
-      updateTaskDetailsDefinition,
-      addTaskCommentDefinition,
-      updateTaskStatusDefinition,
-      listWorkflowStatusesDefinition,
-      myTasksDefinition,
-      listActivitiesTool,
-      getRecentUpdatesTool,
-      listTimeEntriesDefinition,
-      createTimeEntryDefinition,
-      listProjectDealsDefinition,
-      listDealServicesDefinition,
-      listServicesDefinition,
-      getProjectServicesDefinition,
-      updateTaskSprintTool,
-      moveTaskToListTool,
-      addToBacklogTool,
-      taskRepositionDefinition,
-      deleteTaskDefinition,
-      // Folders
-      listFoldersTool,
-      getFolderTool,
-      createFolderTool,
-      updateFolderTool,
-      archiveFolderTool,
-      restoreFolderTool,
-      // Subtasks
-      listSubtasksDefinition,
-      createSubtaskDefinition,
-      // Comments (expanded)
-      listCommentsDefinition,
-      getCommentDefinition,
-      updateCommentDefinition,
-      deleteCommentDefinition,
-      pinCommentDefinition,
-      unpinCommentDefinition,
-      addCommentReactionDefinition,
-      // Todos
-      listTodosDefinition,
-      getTodoDefinition,
-      createTodoDefinition,
-      updateTodoDefinition,
-      deleteTodoDefinition,
-      // Pages
-      listPagesDefinition,
-      getPageDefinition,
-      createPageDefinition,
-      updatePageDefinition,
-      deletePageDefinition,
-      movePageDefinition,
-      copyPageDefinition,
-      // People
-      listPeopleDefinition,
-      getPersonDefinition,
-      // Task Dependencies
-      listTaskDependenciesDefinition,
-      getTaskDependencyDefinition,
-      createTaskDependencyDefinition,
-      deleteTaskDependencyDefinition,
-      // Attachments
-      getAttachmentDefinition,
-    ],
+    tools: toolDefinitions,
   }));
   
   server.setRequestHandler(CallToolRequestSchema, async (request) => {

--- a/src/tools/time-entries.ts
+++ b/src/tools/time-entries.ts
@@ -77,7 +77,7 @@ const createTimeEntrySchema = z.object({
   time: z.string().min(1, 'Time is required'),
   person_id: z.string().min(1, 'Person ID is required'),
   service_id: z.string().min(1, 'Service ID is required'),
-  task_id: z.string().optional().describe('Optional task ID - use list_project_tasks to find available tasks for the project'),
+  task_id: z.string().optional().describe('Optional task ID - use get_project_tasks to find available tasks for the project'),
   note: z.string().min(10, 'Work description must be at least 10 characters').describe('REQUIRED: Detailed description of work performed - be specific about what was accomplished, including bullet points if multiple items'),
   billable_time: z.string().optional(),
   confirm: z.boolean().optional().default(false),
@@ -549,7 +549,7 @@ export const listTimeEntriesDefinition = {
 
 export const createTimeEntryDefinition = {
   name: 'create_time_entry',
-  description: 'STEP 5 (FINAL) of timesheet workflow: Create a time entry with detailed work description. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) list_project_tasks (recommended) → 5) create_time_entry. You MUST provide: valid service_id from the hierarchy, detailed work notes (minimum 10 chars), and optionally link to a specific task_id. This tool requires confirmation before creating. If PRODUCTIVE_USER_ID is configured, use "me" for person_id.',
+  description: 'STEP 5 (FINAL) of timesheet workflow: Create a time entry with detailed work description. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) get_project_tasks (recommended) → 5) create_time_entry. You MUST provide: valid service_id from the hierarchy, detailed work notes (minimum 10 chars), and optionally link to a specific task_id. This tool requires confirmation before creating. If PRODUCTIVE_USER_ID is configured, use "me" for person_id.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -571,7 +571,7 @@ export const createTimeEntryDefinition = {
       },
       task_id: {
         type: 'string',
-        description: 'ID of the task being worked on (recommended - use list_project_tasks to find available tasks)',
+        description: 'ID of the task being worked on (recommended - use get_project_tasks to find available tasks)',
       },
       note: {
         type: 'string',
@@ -738,7 +738,7 @@ export async function listDealServicesTool(
 
 export const listProjectDealsDefinition = {
   name: 'list_project_deals',
-  description: 'STEP 2 of timesheet workflow: Get deals/budgets for a specific project. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) list_project_tasks (recommended) → 5) create_time_entry. This follows: Project → Deal/Budget → Service → Task → Time Entry.',
+  description: 'STEP 2 of timesheet workflow: Get deals/budgets for a specific project. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) get_project_tasks (recommended) → 5) create_time_entry. This follows: Project → Deal/Budget → Service → Task → Time Entry.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -766,7 +766,7 @@ export const listProjectDealsDefinition = {
 
 export const listDealServicesDefinition = {
   name: 'list_deal_services',
-  description: 'STEP 3 of timesheet workflow: Get services for a specific deal/budget. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) list_project_tasks (recommended) → 5) create_time_entry. After this, optionally use list_project_tasks to find specific tasks to link your time entry to.',
+  description: 'STEP 3 of timesheet workflow: Get services for a specific deal/budget. COMPLETE WORKFLOW: 1) list_projects → 2) list_project_deals → 3) list_deal_services → 4) get_project_tasks (recommended) → 5) create_time_entry. After this, optionally use get_project_tasks to find specific tasks to link your time entry to.',
   inputSchema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Problem

Five descriptions in `src/tools/time-entries.ts` instruct the model to call **`list_project_tasks`**. No such tool is registered. The real name is **`get_project_tasks`**.

It is baked into the documented timesheet workflow, which three separate tools repeat verbatim:

> COMPLETE WORKFLOW: 1) `list_projects` → 2) `list_project_deals` → 3) `list_deal_services` → 4) **`list_project_tasks`** (recommended) → 5) `create_time_entry`

So following the instructions in `create_time_entry`, `list_project_deals` or `list_deal_services` produces an "Unknown tool" error partway through the sequence, and the model is left guessing at the right name. It hits the timesheet flow, which is one of the most-used paths in this server.

## The fix

Rename all five references to `get_project_tasks`. Locations: `time-entries.ts:80` (Zod `.describe`), `:552` (`create_time_entry`), `:574` (its `task_id` param), `:741` (`list_project_deals`), `:769` (`list_deal_services`).

## Regression test

`src/__tests__/tool-definitions.test.ts` guards the advertised surface. It extracts every snake_case token from a tool's description and input schema that looks like a tool name (matching this server's `list_`, `get_`, `create_`, `update_`, `delete_`, ... prefixes, excluding known parameter names) and asserts each one resolves to a registered tool. A renamed or imagined tool cannot silently ship again.

I verified the guard is not vacuous by reintroducing the original bug before restoring the fix. It fails with the offending tool named:

```
AssertionError: expected [ { tool: 'create_time_entry', reference: 'list_project_tasks' } ] to deeply equal []
```

The test also covers unique names and the presence of a name and description on every tool. A sweep across all 71 tools found no other dangling references.

## Supporting change

To make the surface testable without standing up a stdio transport, `server.ts` now exports the tool array it previously built inline inside `createServer`, and the `ListTools` handler returns that array. Same list, one source of truth, no behaviour change.

## Verification

`tools/list` over stdio returns 71 tools, unchanged. Type-check clean, 54 tests passing (`npx vitest run --dir src`).

Independent of #30; both branch from `main` and touch different files apart from `server.ts`, where #30 adds one entry to the same list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)