### PR TITLE
fix: deliver server instructions so a task ID routes to get_task_overview

### DIFF
--- a/src/__tests__/server-instructions.test.ts
+++ b/src/__tests__/server-instructions.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Guards the cross-tool routing rule that stops a client calling get_task
+ *               and then get_task_overview for the same task.
+ *
+ * The rule lives in the MCP `instructions` field rather than a tool description, because a
+ * model weighs each tool description on its own and the literal name match wins. Tool
+ * descriptions still carry a matching redirect as a second line of defence.
+ *
+ * @module __tests__/server-instructions.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildInstructions } from '../server-instructions.js';
+import { getTaskDefinition } from '../tools/tasks.js';
+import { getTaskOverviewDefinition } from '../tools/task-overview.js';
+import { getCommentDefinition } from '../tools/comments.js';
+
+describe('buildInstructions', () => {
+  it('routes a task ID to get_task_overview and names the wasteful sequence', () => {
+    const text = buildInstructions('686685');
+
+    expect(text).toContain('get_task_overview FIRST');
+    expect(text).toMatch(/Do NOT call get_task, list_comments or get_comment first/);
+  });
+
+  it('explains the "me" shorthand when a user is configured', () => {
+    expect(buildInstructions('686685')).toContain('686685');
+    expect(buildInstructions('686685')).toContain('"me"');
+  });
+
+  it('says the shorthand is unavailable when no user is configured', () => {
+    const text = buildInstructions(undefined);
+
+    expect(text).toContain('PRODUCTIVE_USER_ID');
+    expect(text).not.toContain('assignee_id');
+  });
+});
+
+describe('task-reading tool descriptions', () => {
+  it('get_task points at get_task_overview before describing itself', () => {
+    const d = getTaskDefinition.description;
+
+    // The redirect must come before any mention of what get_task returns, since a model
+    // that stops reading after the first clause should already have been sent away.
+    expect(d.indexOf('get_task_overview')).toBeLessThan(d.indexOf('ONLY'));
+    expect(d).toContain('wasted round trip');
+  });
+
+  it('get_comment points at get_task_overview for whole threads', () => {
+    expect(getCommentDefinition.description).toContain('get_task_overview');
+  });
+
+  it('get_task_overview still claims the entry point', () => {
+    expect(getTaskOverviewDefinition.description).toContain('START HERE');
+  });
+});

--- a/src/__tests__/server-instructions.test.ts
+++ b/src/__tests__/server-instructions.test.ts
@@ -10,10 +10,29 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { buildInstructions } from '../server-instructions.js';
+import { SERVER_INFO, buildInstructions, buildServerOptions } from '../server-instructions.js';
 import { getTaskDefinition } from '../tools/tasks.js';
 import { getTaskOverviewDefinition } from '../tools/task-overview.js';
 import { getCommentDefinition } from '../tools/comments.js';
+
+describe('buildServerOptions', () => {
+  // The original bug: guidance was put on the Implementation object as `description`, which
+  // the SDK never reads. These two assertions are the regression guard for that shape.
+  it('puts the instructions on ServerOptions, where the SDK reads them', () => {
+    const options = buildServerOptions('686685');
+
+    expect(typeof options.instructions).toBe('string');
+    expect(options.instructions).toContain('get_task_overview');
+  });
+
+  it('keeps guidance off the Implementation object, where it would be dropped', () => {
+    expect(Object.keys(SERVER_INFO).sort()).toEqual(['name', 'version']);
+  });
+
+  it('still declares the tool and prompt capabilities', () => {
+    expect(buildServerOptions('686685').capabilities).toMatchObject({ tools: {}, prompts: {} });
+  });
+});
 
 describe('buildInstructions', () => {
   it('routes a task ID to get_task_overview and names the wasteful sequence', () => {
@@ -23,9 +42,20 @@ describe('buildInstructions', () => {
     expect(text).toMatch(/Do NOT call get_task, list_comments or get_comment first/);
   });
 
-  it('explains the "me" shorthand when a user is configured', () => {
-    expect(buildInstructions('686685')).toContain('686685');
-    expect(buildInstructions('686685')).toContain('"me"');
+  it('sends deeper comment history to comment_limit rather than list_comments', () => {
+    expect(buildInstructions('686685')).toContain('comment_limit');
+  });
+
+  it('names only the tools that actually resolve "me", and routes listing to my_tasks', () => {
+    const text = buildInstructions('686685');
+
+    expect(text).toContain('686685');
+    // These four resolve "me" internally; list_tasks forwards it raw to the API.
+    for (const tool of ['create_task', 'update_task_assignment', 'create_time_entry', 'list_time_entries']) {
+      expect(text).toContain(tool);
+    }
+    expect(text).toContain('my_tasks');
+    expect(text).toMatch(/list_tasks forwards assignee_id/);
   });
 
   it('says the shorthand is unavailable when no user is configured', () => {
@@ -39,10 +69,15 @@ describe('buildInstructions', () => {
 describe('task-reading tool descriptions', () => {
   it('get_task points at get_task_overview before describing itself', () => {
     const d = getTaskDefinition.description;
+    const redirect = d.indexOf('get_task_overview');
+    const caveat = d.indexOf('ONLY');
 
-    // The redirect must come before any mention of what get_task returns, since a model
-    // that stops reading after the first clause should already have been sent away.
-    expect(d.indexOf('get_task_overview')).toBeLessThan(d.indexOf('ONLY'));
+    // Both must be present: a bare `redirect < caveat` passes at -1 if the redirect is
+    // deleted outright, which is the exact drift this test exists to catch.
+    expect(redirect).toBeGreaterThanOrEqual(0);
+    expect(caveat).toBeGreaterThanOrEqual(0);
+    // A model that stops reading after the first clause should already have been sent away.
+    expect(redirect).toBeLessThan(caveat);
     expect(d).toContain('wasted round trip');
   });
 

--- a/src/server-instructions.ts
+++ b/src/server-instructions.ts
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Server-level instructions sent to the client at initialize.
+ *
+ * These reach the model as the MCP `instructions` field on InitializeResult, which is
+ * where cross-tool routing rules belong. Tool descriptions alone cannot express "call A
+ * before B", because a model reading a list of tools weighs each description on its own
+ * and the literal name match usually wins.
+ *
+ * Keep this short. It is spent on every session that connects to this server.
+ *
+ * @module server-instructions
+ */
+
+/**
+ * Build the instructions string for this server.
+ *
+ * @param userId - The configured PRODUCTIVE_USER_ID, if any. Enables the "me" shorthand.
+ * @returns The instructions to advertise at initialize.
+ */
+export function buildInstructions(userId?: string): string {
+  const userContext = userId
+    ? `When the user says "me" or "assign to me", pass the literal string "me" as assignee_id. It resolves to the configured user (ID ${userId}). Call whoami to confirm who that is.`
+    : `No user is configured, so the "me" shorthand is unavailable. Set PRODUCTIVE_USER_ID to enable it.`;
+
+  return [
+    'Productive.io. The hierarchy is Customers > Projects > Boards > Task Lists > Tasks.',
+    '',
+    'READING A TASK',
+    'Given a task or issue ID, call get_task_overview FIRST. It returns metadata, the full',
+    'description and the full recent comment bodies with an attachment index in one call.',
+    'Do NOT call get_task, list_comments or get_comment first and then get_task_overview:',
+    'the overview already contains all of it, so the earlier call is a wasted round trip.',
+    'Reach for get_task only to re-check a single metadata field on a task whose thread you',
+    'have already read, and for get_comment only to fetch one comment the overview omitted',
+    'because it fell outside comment_limit.',
+    '',
+    'USER CONTEXT',
+    userContext,
+  ].join('\n');
+}

--- a/src/server-instructions.ts
+++ b/src/server-instructions.ts
@@ -1,26 +1,51 @@
 /**
- * @fileoverview Server-level instructions sent to the client at initialize.
+ * @fileoverview The two arguments handed to the MCP `Server` constructor.
  *
- * These reach the model as the MCP `instructions` field on InitializeResult, which is
+ * Kept out of server.ts so they can be asserted on directly. `createServer` connects a stdio
+ * transport before it returns, so a test cannot call it to inspect what was built.
+ *
+ * The instructions reach the model as the `instructions` field on InitializeResult, which is
  * where cross-tool routing rules belong. Tool descriptions alone cannot express "call A
- * before B", because a model reading a list of tools weighs each description on its own
- * and the literal name match usually wins.
+ * before B", because a model reading a list of tools weighs each description on its own and
+ * the literal name match usually wins.
  *
- * Keep this short. It is spent on every session that connects to this server.
+ * Note the shape carefully. `instructions` belongs on the SECOND constructor argument
+ * (ServerOptions). A `description` key on the first argument (Implementation) is not an MCP
+ * field, is never read by the SDK, and is silently dropped. That was the original bug.
  *
  * @module server-instructions
  */
 
+import type { ServerOptions } from '@modelcontextprotocol/sdk/server/index.js';
+import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
+
+/** Identity advertised at initialize. Deliberately carries no guidance: the SDK would drop it. */
+export const SERVER_INFO: Implementation = {
+  name: 'productive-mcp',
+  version: '1.0.0',
+};
+
 /**
  * Build the instructions string for this server.
+ *
+ * Keep it short. It is spent on every session that connects.
  *
  * @param userId - The configured PRODUCTIVE_USER_ID, if any. Enables the "me" shorthand.
  * @returns The instructions to advertise at initialize.
  */
 export function buildInstructions(userId?: string): string {
+  // "me" is resolved per-tool, not centrally, so listing the tools that honour it is the
+  // difference between a working shorthand and a filter that silently does nothing.
   const userContext = userId
-    ? `When the user says "me" or "assign to me", pass the literal string "me" as assignee_id. It resolves to the configured user (ID ${userId}). Call whoami to confirm who that is.`
-    : `No user is configured, so the "me" shorthand is unavailable. Set PRODUCTIVE_USER_ID to enable it.`;
+    ? [
+        `You are acting as the user with ID ${userId}. Call whoami to confirm.`,
+        'Pass the literal string "me" only to create_task and update_task_assignment',
+        '(as assignee_id), and to create_time_entry and list_time_entries (as person_id).',
+        'Those tools resolve it. Others do NOT: list_tasks forwards assignee_id straight',
+        'to the API, so "me" there is not a filter for you. To list your own tasks use',
+        'my_tasks.',
+      ].join('\n')
+    : 'No user is configured, so the "me" shorthand is unavailable. Set PRODUCTIVE_USER_ID to enable it.';
 
   return [
     'Productive.io. The hierarchy is Customers > Projects > Boards > Task Lists > Tasks.',
@@ -30,11 +55,27 @@ export function buildInstructions(userId?: string): string {
     'description and the full recent comment bodies with an attachment index in one call.',
     'Do NOT call get_task, list_comments or get_comment first and then get_task_overview:',
     'the overview already contains all of it, so the earlier call is a wasted round trip.',
-    'Reach for get_task only to re-check a single metadata field on a task whose thread you',
-    'have already read, and for get_comment only to fetch one comment the overview omitted',
-    'because it fell outside comment_limit.',
+    'If you need comments older than the ones returned, raise the overview\'s comment_limit',
+    '(up to 50) rather than reaching for list_comments.',
+    'Use get_task only for a task attribute the overview omits (updated_at, priority) or to',
+    're-check one field on a task whose thread you have already read.',
     '',
     'USER CONTEXT',
     userContext,
   ].join('\n');
+}
+
+/**
+ * Build the ServerOptions, including the instructions the client will surface.
+ *
+ * @param userId - The configured PRODUCTIVE_USER_ID, if any.
+ */
+export function buildServerOptions(userId?: string): ServerOptions {
+  return {
+    capabilities: {
+      tools: {},
+      prompts: {},
+    },
+    instructions: buildInstructions(userId),
+  };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema, ListPromptsRequestSchema, GetPromptRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { getConfig } from './config/index.js';
+import { buildInstructions } from './server-instructions.js';
 import { ProductiveAPIClient } from './api/client.js';
 import { listProjectsTool, listProjectsDefinition } from './tools/projects.js';
 import { listTasksTool, getProjectTasksTool, getTaskTool, createTaskTool, updateTaskAssignmentTool, updateTaskDetailsTool, deleteTaskTool, listTasksDefinition, getProjectTasksDefinition, getTaskDefinition, createTaskDefinition, updateTaskAssignmentDefinition, updateTaskDetailsDefinition, deleteTaskDefinition } from './tools/tasks.js';
@@ -122,19 +123,18 @@ export const toolDefinitions = [
 export async function createServer() {
   // Initialize API client and config early to check user context
   const config = getConfig();
-  const hasConfiguredUser = !!config.PRODUCTIVE_USER_ID;
-  
+
   const server = new Server(
     {
       name: 'productive-mcp',
       version: '1.0.0',
-      description: `MCP server for Productive.io API integration. Productive has a hierarchical structure: Customers → Projects → Boards → Task Lists → Tasks.${hasConfiguredUser ? ` IMPORTANT: When users say "me" or "assign to me", use "me" as the assignee_id value - it automatically resolves to the configured user ID ${config.PRODUCTIVE_USER_ID}.` : ' No user configured - set PRODUCTIVE_USER_ID to enable "me" context.'} Use the 'whoami' tool to check current user context.`,
     },
     {
       capabilities: {
         tools: {},
         prompts: {},
       },
+      instructions: buildInstructions(config.PRODUCTIVE_USER_ID),
     }
   );
   const apiClient = new ProductiveAPIClient(config);

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema, ListPromptsRequestSchema, GetPromptRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { getConfig } from './config/index.js';
-import { buildInstructions } from './server-instructions.js';
+import { SERVER_INFO, buildServerOptions } from './server-instructions.js';
 import { ProductiveAPIClient } from './api/client.js';
 import { listProjectsTool, listProjectsDefinition } from './tools/projects.js';
 import { listTasksTool, getProjectTasksTool, getTaskTool, createTaskTool, updateTaskAssignmentTool, updateTaskDetailsTool, deleteTaskTool, listTasksDefinition, getProjectTasksDefinition, getTaskDefinition, createTaskDefinition, updateTaskAssignmentDefinition, updateTaskDetailsDefinition, deleteTaskDefinition } from './tools/tasks.js';
@@ -124,19 +124,8 @@ export async function createServer() {
   // Initialize API client and config early to check user context
   const config = getConfig();
 
-  const server = new Server(
-    {
-      name: 'productive-mcp',
-      version: '1.0.0',
-    },
-    {
-      capabilities: {
-        tools: {},
-        prompts: {},
-      },
-      instructions: buildInstructions(config.PRODUCTIVE_USER_ID),
-    }
-  );
+  // instructions must ride on the second argument. See server-instructions.ts.
+  const server = new Server(SERVER_INFO, buildServerOptions(config.PRODUCTIVE_USER_ID));
   const apiClient = new ProductiveAPIClient(config);
   
   // Register handlers

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -275,7 +275,7 @@ export async function getCommentTool(
 
 export const getCommentDefinition = {
   name: 'get_comment',
-  description: 'Get a single comment by ID from Productive.io with all attributes.',
+  description: 'Get a single comment by ID. Use this only for one specific comment you already know the ID of, typically one that fell outside get_task_overview\'s comment_limit. To read a task\'s thread, call get_task_overview, which returns full comment bodies in one call.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -355,7 +355,7 @@ export const getProjectTasksDefinition = {
 
 export const getTaskDefinition = {
   name: 'get_task',
-  description: 'NOT the tool for reading a task. Call get_task_overview instead: it returns everything this returns, plus the full comment thread and an attachment index, in the same single call. Calling get_task first and get_task_overview afterwards is always a wasted round trip. Use get_task ONLY to re-check a metadata field (status, assignee, due date) on a task whose thread you have already read.',
+  description: 'NOT the tool for reading or understanding a task. Call get_task_overview instead: it covers this tool\'s common fields (title, status, assignee, project, task list, dates, estimate vs worked time) and adds the full comment thread and an attachment index, in the same single call. Calling get_task first and get_task_overview afterwards is always a wasted round trip. Use get_task ONLY for a field the overview omits (updated_at, priority, placement) or to re-check one field on a task whose thread you have already read.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -355,7 +355,7 @@ export const getProjectTasksDefinition = {
 
 export const getTaskDefinition = {
   name: 'get_task',
-  description: 'Get detailed information about a specific task by ID. Returns metadata only, with no comment history. To understand an issue you have been given the ID for, prefer get_task_overview, which returns this metadata plus the full recent comment thread and an attachment index in a single call.',
+  description: 'NOT the tool for reading a task. Call get_task_overview instead: it returns everything this returns, plus the full comment thread and an attachment index, in the same single call. Calling get_task first and get_task_overview afterwards is always a wasted round trip. Use get_task ONLY to re-check a metadata field (status, assignee, due date) on a task whose thread you have already read.',
   inputSchema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## The symptom

A live session called `get_task` and then `get_task_overview` for the same task. That is
precisely the round trip `get_task_overview` (PR #30) was built to remove.

## The cause is not wording

`get_task` already carried a redirect, and it was being served correctly. The real problem
sits one level up: **this server's guidance never reached a model at all.**

`src/server.ts` put it in a `description` key on the implementation-info object:

```ts
new Server(
  { name: 'productive-mcp', version: '1.0.0', description: 'MCP server for Productive.io...' },
  { capabilities: { tools: {}, prompts: {} } }
);
```

`description` is not an MCP field on `Implementation`. The field clients surface is
`instructions`, and it belongs in **ServerOptions**, the second argument. Confirmed directly
against the SDK:

```
old (description on serverInfo): undefined
new (instructions on options):  "guidance that lands"
```

Corroborating evidence: in a Claude session with this server connected, the "MCP Server
Instructions" section of the system prompt lists the other connected servers but **not**
`productive`. So the hierarchy explanation and the `"me"` assignee-resolution rule were
both silently dropped, and had never been delivered.

## Why the rule has to live there

A tool description cannot express "call A before B". A model weighs each description on its
own merits, and given a task ID the literal name match (`get_task`) wins. Cross-tool routing
is exactly what `instructions` is for.

## The change

- New `src/server-instructions.ts` stating the routing rule outright: given a task ID, call
  `get_task_overview` first, and do not call `get_task` / `list_comments` / `get_comment`
  first and then the overview. It also says when each narrow tool *is* right, so they stay
  usable rather than becoming dead weight.
- `server.ts` passes `instructions` in ServerOptions and drops the inert `description`.
- `get_task` now leads with the redirect. It previously opened with "Get detailed information
  about a specific task by ID" and buried a soft "prefer get_task_overview" in the last
  sentence, so a model that decided on the first clause never reached the advice.
- `get_comment` picks up the same redirect for whole-thread reads.
- Tests cover the rule text, the `"me"` branch both ways, and the redirect ordering in
  `get_task` so it cannot drift back to being buried.

## Verification

Spawned the built server over stdio with a real MCP client: `getInstructions()` now returns
the full text, and all 72 tools still list. Type-check clean, 92 tests passing
(`npx vitest run --dir src`).

Note this fix also restores the `"me"` assignee shorthand guidance, which has been
undelivered for as long as the `description` key has been there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)