### PR TITLE
feat: annotate all 72 tools so a client can tell delete_task from list_tasks

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema, ListPromptsRequestSchema
 import { z } from 'zod';
 import { getConfig } from './config/index.js';
 import { SERVER_INFO, buildServerOptions } from './server-instructions.js';
+import { withAnnotations } from './tools/annotations.js';
 import { ProductiveAPIClient } from './api/client.js';
 import { listProjectsTool, listProjectsDefinition } from './tools/projects.js';
 import { listTasksTool, getProjectTasksTool, getTaskTool, createTaskTool, updateTaskAssignmentTool, updateTaskDetailsTool, deleteTaskTool, listTasksDefinition, getProjectTasksDefinition, getTaskDefinition, createTaskDefinition, updateTaskAssignmentDefinition, updateTaskDetailsDefinition, deleteTaskDefinition } from './tools/tasks.js';
@@ -130,7 +131,7 @@ export async function createServer() {
   
   // Register handlers
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: toolDefinitions,
+    tools: withAnnotations(toolDefinitions),
   }));
   
   server.setRequestHandler(CallToolRequestSchema, async (request) => {

--- a/src/tools/__tests__/annotations.test.ts
+++ b/src/tools/__tests__/annotations.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Guards the behaviour hints on the tool surface.
+ *
+ * Two things matter here. Every registered tool must be classified, so a new one cannot ship
+ * looking as harmless as list_tasks. And the destructive set must be pinned by name, so
+ * flipping delete_task to read-only is a test failure rather than a quiet loss of the only
+ * signal a client has for gating it.
+ *
+ * @module tools/__tests__/annotations.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toolDefinitions } from '../../server.js';
+import { TOOL_ANNOTATIONS, assertAnnotationsCover, withAnnotations } from '../annotations.js';
+
+const names = toolDefinitions.map(d => d.name);
+
+/** Every tool that removes or overwrites existing data. Changing this list should be deliberate. */
+const DESTRUCTIVE = [
+  'archive_folder',
+  'archive_task_list',
+  'delete_comment',
+  'delete_page',
+  'delete_task',
+  'delete_task_dependency',
+  'delete_todo',
+  'update_comment',
+  'update_folder',
+  'update_page',
+  'update_task_assignment',
+  'update_task_details',
+  'update_task_list',
+  'update_task_sprint',
+  'update_task_status',
+  'update_todo',
+];
+
+describe('annotation coverage', () => {
+  it('classifies every registered tool, with no entries for tools that no longer exist', () => {
+    expect(assertAnnotationsCover(names)).toEqual({ missing: [], orphaned: [] });
+  });
+
+  it('covers the whole surface', () => {
+    expect(names.length).toBe(72);
+    expect(Object.keys(TOOL_ANNOTATIONS)).toHaveLength(72);
+  });
+
+  it('gives every tool a human-readable title', () => {
+    for (const [name, a] of Object.entries(TOOL_ANNOTATIONS)) {
+      expect(a.title, name).toBeTruthy();
+    }
+  });
+});
+
+describe('classification', () => {
+  it('flags exactly the tools that remove or overwrite data', () => {
+    const flagged = Object.entries(TOOL_ANNOTATIONS)
+      .filter(([, a]) => a.destructiveHint)
+      .map(([n]) => n)
+      .sort();
+
+    expect(flagged).toEqual(DESTRUCTIVE);
+  });
+
+  it('never marks a tool both read-only and destructive', () => {
+    for (const [name, a] of Object.entries(TOOL_ANNOTATIONS)) {
+      if (a.readOnlyHint) {
+        expect(a.destructiveHint, name).toBeFalsy();
+      }
+    }
+  });
+
+  it('treats every delete_ and archive_ tool as destructive', () => {
+    for (const name of names.filter(n => n.startsWith('delete_') || n.startsWith('archive_'))) {
+      expect(TOOL_ANNOTATIONS[name].destructiveHint, name).toBe(true);
+    }
+  });
+
+  it('treats every list_ and get_ tool as read-only', () => {
+    for (const name of names.filter(n => n.startsWith('list_') || n.startsWith('get_'))) {
+      expect(TOOL_ANNOTATIONS[name].readOnlyHint, name).toBe(true);
+    }
+  });
+
+  it('marks creates as non-idempotent, since each call makes another one', () => {
+    for (const name of names.filter(n => n.startsWith('create_') || n.startsWith('copy_'))) {
+      expect(TOOL_ANNOTATIONS[name].idempotentHint, name).toBe(false);
+      expect(TOOL_ANNOTATIONS[name].destructiveHint, name).toBe(false);
+    }
+  });
+
+  it('marks reads as open-world, because Productive is shared with other people', () => {
+    expect(TOOL_ANNOTATIONS.list_tasks.openWorldHint).toBe(true);
+  });
+});
+
+describe('withAnnotations', () => {
+  it('attaches the hints to every definition', () => {
+    const annotated = withAnnotations(toolDefinitions);
+
+    expect(annotated).toHaveLength(toolDefinitions.length);
+    for (const d of annotated) {
+      expect(d.annotations, d.name).toBeDefined();
+    }
+  });
+
+  it('distinguishes delete_task from list_tasks, which was the whole problem', () => {
+    const byName = Object.fromEntries(withAnnotations(toolDefinitions).map(d => [d.name, d.annotations]));
+
+    expect(byName.list_tasks?.readOnlyHint).toBe(true);
+    expect(byName.delete_task?.readOnlyHint).toBe(false);
+    expect(byName.delete_task?.destructiveHint).toBe(true);
+  });
+
+  it('leaves a definition that carries its own annotations untouched', () => {
+    const own = { name: 'list_tasks', annotations: { title: 'Bespoke' } };
+
+    expect(withAnnotations([own])[0].annotations).toEqual({ title: 'Bespoke' });
+  });
+});

--- a/src/tools/annotations.ts
+++ b/src/tools/annotations.ts
@@ -1,0 +1,195 @@
+/**
+ * @fileoverview Behaviour hints for every registered tool.
+ *
+ * Without these, a client cannot tell delete_task from list_tasks: both are just a name and a
+ * schema, so nothing can gate the destructive ones or safely retry the idempotent ones.
+ *
+ * Kept as one table rather than scattered across the definition files so the safety
+ * classification can be read and audited in a single place. `assertAnnotationsCover` is
+ * called by a test, so a new tool cannot ship unclassified.
+ *
+ * These are HINTS. The SDK is explicit that clients must not treat them as a security
+ * boundary, and nothing here replaces a real confirmation gate on a destructive tool.
+ *
+ * The policy, applied consistently below:
+ *
+ * - `readOnlyHint`  true when the call changes nothing in Productive.
+ * - `destructiveHint` true when it removes or overwrites existing data (delete, archive, and
+ *   any update that replaces a value). False when the change is purely additive, which is
+ *   what the spec means by the distinction between an insert and an update or delete.
+ * - `idempotentHint` true when repeating the call with the same arguments leaves the same end
+ *   state. Creates are false, because each call makes another one.
+ * - `openWorldHint` true throughout: Productive is a shared external system, so results can
+ *   change between two identical calls because of what other people did.
+ *
+ * @module tools/annotations
+ */
+
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+
+/** Reads Productive and changes nothing. */
+function read(title: string): ToolAnnotations {
+  return { title, readOnlyHint: true, openWorldHint: true };
+}
+
+/** Adds something new. Calling it again adds another. */
+function create(title: string): ToolAnnotations {
+  return {
+    title,
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  };
+}
+
+/** Sets a value without discarding anything. Repeating it is a no-op. */
+function set(title: string): ToolAnnotations {
+  return {
+    title,
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  };
+}
+
+/** Overwrites or removes existing data. Repeating it leaves the same end state. */
+function destroy(title: string): ToolAnnotations {
+  return {
+    title,
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: true,
+  };
+}
+
+/**
+ * Behaviour hints keyed by tool name.
+ *
+ * Every name registered in server.ts must appear here exactly once.
+ */
+export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = {
+  // Reads. get_attachment is included deliberately: it writes a file into the local
+  // attachment cache, but changes nothing in Productive, which is what the hint describes.
+  get_attachment: read('Get attachment'),
+  get_comment: read('Get comment'),
+  get_folder: read('Get folder'),
+  get_page: read('Get page'),
+  get_person: read('Get person'),
+  get_project_services: read('Get project services (deprecated)'),
+  get_project_tasks: read('Get project tasks'),
+  get_recent_updates: read('Get recent updates'),
+  get_task: read('Get task metadata only'),
+  get_task_dependency: read('Get task dependency'),
+  get_task_list: read('Get task list'),
+  get_task_overview: read('Task briefing (start here)'),
+  get_todo: read('Get todo'),
+  list_activities: read('List activities'),
+  list_boards: read('List boards'),
+  list_comments: read('List comments (bodies truncated)'),
+  list_companies: read('List companies'),
+  list_deal_services: read('List deal services'),
+  list_folders: read('List folders'),
+  list_pages: read('List pages'),
+  list_people: read('List people'),
+  list_project_deals: read('List project deals'),
+  list_projects: read('List projects'),
+  list_services: read('List services (deprecated)'),
+  list_subtasks: read('List subtasks'),
+  list_task_dependencies: read('List task dependencies'),
+  list_task_lists: read('List task lists'),
+  list_tasks: read('List tasks'),
+  list_time_entries: read('List time entries'),
+  list_todos: read('List todos'),
+  list_workflow_statuses: read('List workflow statuses'),
+  my_tasks: read('My tasks'),
+  whoami: read('Who am I'),
+
+  // Creates.
+  add_task_comment: create('Add comment to task'),
+  copy_page: create('Copy page'),
+  copy_task_list: create('Copy task list'),
+  create_board: create('Create board'),
+  create_folder: create('Create folder'),
+  create_page: create('Create page'),
+  create_subtask: create('Create subtask'),
+  create_task: create('Create task'),
+  create_task_dependency: create('Create task dependency'),
+  create_task_list: create('Create task list'),
+  create_time_entry: create('Log time entry'),
+  create_todo: create('Create todo'),
+
+  // Additive or positional changes. Nothing is lost, and repeating them changes nothing.
+  add_comment_reaction: set('React to comment'),
+  add_to_backlog: set('Move task to backlog'),
+  move_page: set('Move page'),
+  move_task_list: set('Move task list to board'),
+  move_task_to_list: set('Move task to list'),
+  pin_comment: set('Pin comment'),
+  reposition_task: set('Reposition task'),
+  reposition_task_list: set('Reposition task list'),
+  restore_folder: set('Restore folder'),
+  restore_task_list: set('Restore task list'),
+  unpin_comment: set('Unpin comment'),
+
+  // Overwrites and removals. These are the ones a client should think about gating.
+  archive_folder: destroy('Archive folder'),
+  archive_task_list: destroy('Archive task list'),
+  delete_comment: destroy('Delete comment'),
+  delete_page: destroy('Delete page'),
+  delete_task: destroy('Delete task'),
+  delete_task_dependency: destroy('Delete task dependency'),
+  delete_todo: destroy('Delete todo'),
+  update_comment: destroy('Edit comment'),
+  update_folder: destroy('Update folder'),
+  update_page: destroy('Update page'),
+  update_task_assignment: destroy('Reassign task'),
+  update_task_details: destroy('Update task details'),
+  update_task_list: destroy('Update task list'),
+  update_task_sprint: destroy('Set task sprint'),
+  update_task_status: destroy('Set task status'),
+  update_todo: destroy('Update todo'),
+};
+
+/** A tool definition as registered in server.ts. */
+interface ToolDefinitionLike {
+  name: string;
+  annotations?: ToolAnnotations;
+}
+
+/**
+ * Attach the hints to each definition.
+ *
+ * A definition that already carries its own `annotations` keeps them, so a tool can opt out
+ * of the table without being silently overridden.
+ *
+ * @param definitions - The registered tool definitions.
+ * @returns The same definitions, annotated.
+ */
+export function withAnnotations<T extends { name: string }>(
+  definitions: T[]
+): Array<T & { annotations?: ToolAnnotations }> {
+  return definitions.map(d => {
+    const existing = (d as ToolDefinitionLike).annotations;
+    return existing ? d : { ...d, annotations: TOOL_ANNOTATIONS[d.name] };
+  });
+}
+
+/**
+ * Check the table against the registered tools, in both directions.
+ *
+ * @param names - Every registered tool name.
+ * @returns Tools with no entry, and entries naming a tool that no longer exists.
+ */
+export function assertAnnotationsCover(names: string[]): {
+  missing: string[];
+  orphaned: string[];
+} {
+  const annotated = new Set(Object.keys(TOOL_ANNOTATIONS));
+  return {
+    missing: names.filter(n => !annotated.has(n)).sort(),
+    orphaned: Object.keys(TOOL_ANNOTATIONS).filter(n => !names.includes(n)).sort(),
+  };
+}


### PR DESCRIPTION
## Why

Outstanding item 2 from the tool-surface review. Not one of the 72 tools carried
`readOnlyHint`, `destructiveHint`, `idempotentHint` or a `title`. To a client, every tool was
just a name and a schema, so `delete_task` was indistinguishable in kind from `list_tasks`.
Nothing could gate the destructive ones, and nothing could safely retry the idempotent ones.

Before: `annotated: 0 / 72`. After: `72 / 72`.

## Shape

One table in `src/tools/annotations.ts`, applied centrally in the `ListTools` handler, rather
than 72 scattered edits. The point of centralising is that the safety classification is worth
reading as a single list. A definition carrying its own `annotations` is left alone, so a tool
can still opt out.

## The policy

Documented in the module so the calls are checkable rather than vibes:

| hint | meaning | count |
|---|---|---|
| `readOnlyHint` | changes nothing in Productive | 33 |
| `destructiveHint` | removes or overwrites existing data | 16 |
| neither | additive or positional writes | 23 |

`idempotentHint` is true when repeating the call leaves the same end state, so creates are
false and setters are true. `openWorldHint` is true throughout, because Productive is shared
and results change underneath you between two identical calls.

Note `destructiveHint` follows the spec's insert-versus-update distinction, so the `update_*`
family counts as destructive: it replaces values rather than only adding.

## Judgement calls worth a second opinion

- **`get_attachment` is read-only** despite writing into the local attachment cache, because
  it changes nothing in Productive, which is what the hint describes.
- **`archive_*` is destructive** even though `restore_*` exists. Reversible, but it removes
  things from active use, and the conservative flag is the useful one for a client.
- **`update_*` is destructive, not additive**, per the note above.

## Tests

- `assertAnnotationsCover` checks the table against the registry in both directions, so a new
  tool cannot ship unclassified and a deleted tool cannot leave a stale entry.
- The destructive set is pinned **by name**. Flipping `delete_task` to read-only fails the
  build rather than quietly removing the only signal a client has for gating it.
- Structural rules: no tool is both read-only and destructive; every `delete_`/`archive_` is
  destructive; every `list_`/`get_` is read-only; creates are non-idempotent.

## Verification

Over stdio against a real MCP client: 72 of 72 annotated, and the payload passes SDK schema
validation.

```
list_tasks         {"title":"List tasks","readOnlyHint":true,"openWorldHint":true}
delete_task        {"title":"Delete task","readOnlyHint":false,"destructiveHint":true,"idempotentHint":true,"openWorldHint":true}
create_task        {"title":"Create task","readOnlyHint":false,"destructiveHint":false,"idempotentHint":false,"openWorldHint":true}
```

Type-check clean, 142 tests passing.

## Not in scope

These are hints, and the SDK is explicit that clients must not treat them as a security
boundary. The related review finding still stands: `create_time_entry` is the only tool with a
confirm gate, and none of the five deletes have one. Annotations make that gap *visible* to a
client; they do not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)