### PR TITLE
ci: add GitHub Actions, and make npm test report the real number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# A second push to a PR makes the first run irrelevant, so stop it rather than pay for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Type-check, unit tests, build, and a real handshake against the compiled artifact.
+  # Split by Node version because vitest requires ^20 || ^22 || >=24, so the toolchain cannot
+  # run on the minimum version this package supports. That is covered by `runtime` below.
+  check:
+    name: check (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Report every failing version, not just the first to fall over.
+      fail-fast: false
+      matrix:
+        node: ['20', '22']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Type-check
+        run: npm run type-check
+
+      # No credentials are set on purpose. The suite must not need a live Productive token,
+      # and running it bare is what keeps that true.
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      # Type-checking and unit tests both run against source. This is the only step that
+      # proves the compiled artifact starts, completes an MCP handshake, and advertises the
+      # tool surface. It makes no API calls, so the placeholder token is never used.
+      - name: Smoke-test the built server
+        env:
+          PRODUCTIVE_API_TOKEN: ci-placeholder-not-a-real-token
+          PRODUCTIVE_ORG_ID: '0'
+        run: node scripts/smoke-test.mjs
+
+  # package.json declares engines >= 18. The published server has to actually start there,
+  # even though the dev toolchain cannot. Without this, "we support 18" is an untested claim.
+  runtime:
+    name: runtime (node 18, minimum supported)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Build on a version the toolchain supports, then run the output on the oldest one.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Start the built server on Node 18
+        env:
+          PRODUCTIVE_API_TOKEN: ci-placeholder-not-a-real-token
+          PRODUCTIVE_ORG_ID: '0'
+        run: |
+          node --version
+          node scripts/smoke-test.mjs

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "node build/index.js",
     "prepublishOnly": "npm run build",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "type-check": "tsc --noEmit"
   },
   "keywords": [
     "mcp",

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Starts the built server over stdio and checks the surface it actually serves.
+ *
+ * Type-checking and unit tests both pass against source. This is the only step that proves
+ * the compiled artifact starts, completes an MCP handshake, and advertises what it should.
+ *
+ * Makes no API calls, so it runs with a placeholder token and needs no credentials.
+ *
+ * Usage: node scripts/smoke-test.mjs
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const EXPECTED_TOOL_COUNT = 72;
+
+/** Tools whose annotations a client relies on to gate a destructive call. */
+const MUST_BE_DESTRUCTIVE = ['delete_task', 'delete_comment', 'delete_page', 'delete_todo'];
+
+const failures = [];
+
+/** Record a failure rather than throwing, so one run reports everything wrong at once. */
+function check(label, condition, detail = '') {
+  if (condition) {
+    console.log(`  ok   ${label}`);
+  } else {
+    console.log(`  FAIL ${label}${detail ? ` (${detail})` : ''}`);
+    failures.push(label);
+  }
+}
+
+const transport = new StdioClientTransport({
+  command: 'node',
+  args: ['build/index.js'],
+  env: {
+    ...process.env,
+    PRODUCTIVE_API_TOKEN: process.env.PRODUCTIVE_API_TOKEN ?? 'smoke-test-placeholder',
+    PRODUCTIVE_ORG_ID: process.env.PRODUCTIVE_ORG_ID ?? '0',
+  },
+});
+
+const client = new Client({ name: 'smoke-test', version: '1.0.0' }, { capabilities: {} });
+
+try {
+  await client.connect(transport);
+  console.log('server started and completed the MCP handshake');
+
+  // Instructions. These are silently dropped if they are ever moved back onto the
+  // implementation-info object, which is a bug no unit test on the built artifact would see.
+  const instructions = client.getInstructions() ?? '';
+  check('serves instructions', instructions.length > 0, `${instructions.length} chars`);
+  check('instructions carry the task-reading rule', instructions.includes('get_task_overview'));
+
+  // Tools.
+  const { tools } = await client.listTools();
+  check(
+    `serves ${EXPECTED_TOOL_COUNT} tools`,
+    tools.length === EXPECTED_TOOL_COUNT,
+    `got ${tools.length}`
+  );
+
+  const unannotated = tools.filter(t => !t.annotations).map(t => t.name);
+  check('every tool is annotated', unannotated.length === 0, unannotated.join(', '));
+
+  const untitled = tools.filter(t => !t.annotations?.title).map(t => t.name);
+  check('every tool has a title', untitled.length === 0, untitled.join(', '));
+
+  const byName = new Map(tools.map(t => [t.name, t]));
+  for (const name of MUST_BE_DESTRUCTIVE) {
+    check(`${name} is flagged destructive`, byName.get(name)?.annotations?.destructiveHint === true);
+  }
+  check(
+    'list_tasks is flagged read-only',
+    byName.get('list_tasks')?.annotations?.readOnlyHint === true
+  );
+
+  // Every tool needs a schema, or a client cannot call it at all.
+  const schemaless = tools.filter(t => !t.inputSchema).map(t => t.name);
+  check('every tool has an input schema', schemaless.length === 0, schemaless.join(', '));
+} catch (error) {
+  console.error('smoke test could not run:', error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+} finally {
+  await client.close().catch(() => {});
+}
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} smoke check(s) failed`);
+  process.exitCode = 1;
+} else if (process.exitCode !== 1) {
+  console.log('\nall smoke checks passed');
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Without an explicit exclude, vitest also collects the compiled copies of every test under
+ * `build/`, which doubled the reported count (284 instead of 142) and meant a stale build
+ * could keep an edited test passing. Only `src` is the source of truth.
+ */
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    exclude: ['**/node_modules/**', 'build/**', 'dist/**'],
+  },
+});


### PR DESCRIPTION
## Why

This repo had no CI. Three PRs merged today with **zero status checks**, verified only by
hand. That hand-verification is what caught an inert server config, instructions that shipped
inaccurate, and a test suite that stayed green while a query parameter was broken. Too much to
keep catching manually.

## `vitest.config.ts` comes first

Without an exclude, vitest also collected the compiled copies of every test under `build/`:

```
npm test          -> Tests  284 passed (284)   # every test run twice
vitest --dir src  -> Tests  142 passed (142)   # the real number
```

That meant a stale `build/` could keep an edited test passing. It also matters here
specifically: **CI builds before it smoke-tests**, so it would have tripped this every run.
With the config, `npm test` reports 142 whether or not a build is present, so the workflow can
just call `npm test` honestly. This was outstanding item 5 from the review.

## Two jobs, because the toolchain and the runtime disagree

`package.json` declares `engines: node >=18`, but `vitest` requires `^20 || ^22 || >=24` (and
`vite` needs `^20.19 || >=22.12`). So the test suite **cannot** run on this package's own
minimum version. I found this while writing the workflow, having initially put `18` in the
matrix, where it would have failed on the toolchain rather than on anything real.

Rather than paper over it by silently bumping `engines`, the jobs are split so each one tests
something true:

- **`check` (node 20, 22)** type-check, test, build, smoke-test.
- **`runtime` (node 18)** builds on 22, then runs the compiled output on 18. Without this,
  "we support Node 18" is an untested claim on a published package.

If you would rather drop Node 18 support outright, deleting the `runtime` job and setting
`engines` to `>=20` is the alternative. I kept 18 because the shipped server genuinely works
there; only the dev tooling does not.

## `scripts/smoke-test.mjs`

Type-checking and unit tests both run against **source**. Nothing covered the artifact that
actually ships. This starts the compiled server over stdio and asserts the handshake
completes, instructions are delivered, and all 72 tools are served, annotated, titled and
schema'd.

It makes no API calls, so the placeholder token is never used, and it doubles as a local tool:
`node scripts/smoke-test.mjs`.

Checked that it fails rather than passing vacuously. Flipping every `destructiveHint` in the
build:

```
  FAIL delete_task is flagged destructive
  FAIL delete_comment is flagged destructive
  FAIL delete_page is flagged destructive
  FAIL delete_todo is flagged destructive
4 smoke check(s) failed        exit code 1
```

## Other choices

- Tests run with **no credentials**, which is what keeps the suite from ever quietly depending
  on a live Productive token.
- `concurrency` with `cancel-in-progress`, so a second push to a PR stops the superseded run.
- `fail-fast: false`, so a failure reports on every Node version rather than just the first.
- Added an explicit `type-check` script, since `tsc --noEmit` had no entry point.

## Verification

Full sequence run locally: type-check clean, 142 tests, build ok, all smoke checks passed. The
workflow YAML parses. This PR's own CI run is the real proof, since a workflow cannot be
properly tested until it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)