### PR TITLE
feat: require confirmation before every delete

### DIFF
--- a/src/tools/__tests__/delete-confirm.test.ts
+++ b/src/tools/__tests__/delete-confirm.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @fileoverview Guards the confirmation gate on every delete tool.
+ *
+ * The assertion that matters is not that a preview is returned, it is that the delete method
+ * is never reached without `confirm: true`. Annotations are hints a client may ignore; this
+ * gate does not depend on the client honouring anything.
+ *
+ * @module tools/__tests__/delete-confirm.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ProductiveAPIClient, ProductiveApiError } from '../../api/client.js';
+import { deleteTaskTool, deleteTaskDefinition } from '../tasks.js';
+import { deleteCommentTool, deleteCommentDefinition } from '../comments.js';
+import { deletePageTool, deletePageDefinition } from '../pages.js';
+import { deleteTodoTool, deleteTodoDefinition } from '../todos.js';
+import { deleteTaskDependencyTool, deleteTaskDependencyDefinition } from '../task-dependencies.js';
+
+function mockClient(overrides: Record<string, unknown>): ProductiveAPIClient {
+  return overrides as unknown as ProductiveAPIClient;
+}
+
+/**
+ * Every gated delete tool, with a lookup stub shaped like the record it fetches and the
+ * argument name it takes.
+ */
+const CASES = [
+  {
+    name: 'delete_task',
+    tool: deleteTaskTool,
+    definition: deleteTaskDefinition,
+    args: { task_id: '19300600' },
+    getter: 'getTask',
+    deleter: 'deleteTask',
+    record: {
+      data: {
+        id: '19300600',
+        attributes: { title: 'Suspended members getting emails/notices', task_number: 407, closed: false },
+        relationships: { project: { data: { id: '813033' } } },
+      },
+    },
+    expectInPreview: 'Suspended members getting emails/notices',
+  },
+  {
+    name: 'delete_comment',
+    tool: deleteCommentTool,
+    definition: deleteCommentDefinition,
+    args: { comment_id: '16843014' },
+    getter: 'getComment',
+    deleter: 'deleteComment',
+    record: {
+      data: {
+        id: '16843014',
+        attributes: { body: '<p>Quick update on Cameron</p>', commentable_type: 'task', created_at: '2026-08-13' },
+        relationships: { task: { data: { id: '19300600' } } },
+      },
+    },
+    expectInPreview: 'Quick update on Cameron',
+  },
+  {
+    name: 'delete_page',
+    tool: deletePageTool,
+    definition: deletePageDefinition,
+    args: { page_id: '55' },
+    getter: 'getPage',
+    deleter: 'deletePage',
+    record: { data: { id: '55', attributes: { title: 'Runbook', body: '<p>Steps</p>' } } },
+    expectInPreview: 'Runbook',
+  },
+  {
+    name: 'delete_todo',
+    tool: deleteTodoTool,
+    definition: deleteTodoDefinition,
+    args: { todo_id: '77' },
+    getter: 'getTodo',
+    deleter: 'deleteTodo',
+    record: { data: { id: '77', attributes: { description: 'Chase Nick', closed: false, due_date: '2026-08-20' } } },
+    expectInPreview: 'Chase Nick',
+  },
+  {
+    name: 'delete_task_dependency',
+    tool: deleteTaskDependencyTool,
+    definition: deleteTaskDependencyDefinition,
+    args: { dependency_id: '9' },
+    getter: 'getTaskDependency',
+    deleter: 'deleteTaskDependency',
+    record: {
+      data: {
+        id: '9',
+        attributes: { type_id: 1 },
+        relationships: { task: { data: { id: '1' } }, dependent_task: { data: { id: '2' } } },
+      },
+    },
+    expectInPreview: 'Dependent task ID: 2',
+  },
+] as const;
+
+describe.each(CASES)('$name confirmation gate', (c) => {
+  /** A client whose lookup succeeds and whose delete is spied on. */
+  function client() {
+    return {
+      [c.getter]: vi.fn().mockResolvedValue(c.record),
+      [c.deleter]: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  it('does not delete when confirm is omitted', async () => {
+    const spy = client();
+
+    await c.tool(mockClient(spy), { ...c.args });
+
+    expect(spy[c.deleter]).not.toHaveBeenCalled();
+  });
+
+  it('does not delete when confirm is explicitly false', async () => {
+    const spy = client();
+
+    await c.tool(mockClient(spy), { ...c.args, confirm: false });
+
+    expect(spy[c.deleter]).not.toHaveBeenCalled();
+  });
+
+  it('describes the record rather than just echoing the ID back', async () => {
+    const spy = client();
+
+    const result = await c.tool(mockClient(spy), { ...c.args });
+    const text = result.content[0].text;
+
+    expect(text).toContain(c.expectInPreview);
+    expect(text).toContain('Nothing has been deleted yet');
+    expect(text).toContain('"confirm": true');
+    expect(spy[c.getter]).toHaveBeenCalled();
+  });
+
+  it('deletes once confirm is true', async () => {
+    const spy = client();
+
+    await c.tool(mockClient(spy), { ...c.args, confirm: true });
+
+    expect(spy[c.deleter]).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the lookup entirely when confirmed, so confirming costs no extra call', async () => {
+    const spy = client();
+
+    await c.tool(mockClient(spy), { ...c.args, confirm: true });
+
+    expect(spy[c.getter]).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a bad ID at preview time, before anything is destroyed', async () => {
+    const notFound = new ProductiveApiError('Record Not Found (404): no such record', 404, [
+      { status: '404', title: 'Record Not Found' },
+    ]);
+    const spy = {
+      [c.getter]: vi.fn().mockRejectedValue(notFound),
+      [c.deleter]: vi.fn(),
+    };
+
+    let caught: any;
+    try {
+      await c.tool(mockClient(spy), { ...c.args });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught.code).toBe(ErrorCode.InvalidParams);
+    expect(spy[c.deleter]).not.toHaveBeenCalled();
+  });
+
+  it('advertises confirm in its input schema and description', () => {
+    expect(c.definition.inputSchema.properties).toHaveProperty('confirm');
+    expect(c.definition.description).toContain('confirm');
+    // Not required, so the safe path is the default rather than something to opt into.
+    expect(c.definition.inputSchema.required).not.toContain('confirm');
+  });
+});

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { toMcpError } from '../utils/errors.js';
+import { confirmField, confirmProperty, deletionPreview, excerpt } from '../utils/confirm.js';
 import { ProductiveIncludedResource } from '../api/types.js';
 import { resolveMentions, MentionResolutionResult } from '../utils/mentions.js';
 import { formatAttachments } from '../utils/attachments.js';
@@ -369,6 +371,7 @@ export const updateCommentDefinition = {
 
 const deleteCommentSchema = z.object({
   comment_id: z.string().min(1, 'Comment ID is required'),
+  confirm: confirmField,
 });
 
 export async function deleteCommentTool(
@@ -377,6 +380,22 @@ export async function deleteCommentTool(
 ): Promise<ToolResult> {
   try {
     const params = deleteCommentSchema.parse(args);
+
+    if (!params.confirm) {
+      // Fetching first means a wrong ID fails here, before anything is destroyed.
+      const { data: record } = await client.getComment(params.comment_id);
+      return deletionPreview({
+        tool: 'delete_comment',
+        kind: 'comment',
+        id: params.comment_id,
+        details: [
+          excerpt(record.attributes.body) ?? '(no body)',
+          `On: ${record.attributes.commentable_type} ${record.relationships?.task?.data?.id ?? ''}`.trim(),
+          `Created: ${record.attributes.created_at}`,
+        ],
+      });
+    }
+
 
     await client.deleteComment(params.comment_id);
 
@@ -387,23 +406,13 @@ export async function deleteCommentTool(
       }],
     };
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
-      );
-    }
-
-    throw new McpError(
-      ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
+    throw toMcpError(error);
   }
 }
 
 export const deleteCommentDefinition = {
   name: 'delete_comment',
-  description: 'Delete a comment by ID from Productive.io.',
+  description: 'Delete a comment by ID from Productive.io. Requires confirmation: the first call only reports what would be deleted, and nothing is removed until you call again with "confirm": true.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -411,6 +420,7 @@ export const deleteCommentDefinition = {
         type: 'string',
         description: 'The ID of the comment to delete (required)',
       },
+      confirm: confirmProperty,
     },
     required: ['comment_id'],
   },

--- a/src/tools/pages.ts
+++ b/src/tools/pages.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { toMcpError } from '../utils/errors.js';
+import { confirmField, confirmProperty, deletionPreview, excerpt } from '../utils/confirm.js';
 
 // ---- Schemas ----
 
@@ -30,6 +32,7 @@ const updatePageSchema = z.object({
 
 const deletePageSchema = z.object({
   page_id: z.string().min(1, 'Page ID is required'),
+  confirm: confirmField,
 });
 
 const movePageSchema = z.object({
@@ -262,6 +265,20 @@ export async function deletePageTool(
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = deletePageSchema.parse(args);
+    if (!params.confirm) {
+      // Fetching first means a wrong ID fails here, before anything is destroyed.
+      const { data: record } = await client.getPage(params.page_id);
+      return deletionPreview({
+        tool: 'delete_page',
+        kind: 'page',
+        id: params.page_id,
+        details: [
+          `Title: ${record.attributes.title}`,
+          excerpt(record.attributes.body),
+        ],
+      });
+    }
+
     await client.deletePage(params.page_id);
 
     return {
@@ -271,17 +288,7 @@ export async function deletePageTool(
       }],
     };
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
-      );
-    }
-
-    throw new McpError(
-      ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
+    throw toMcpError(error);
   }
 }
 
@@ -446,7 +453,7 @@ export const updatePageDefinition = {
 
 export const deletePageDefinition = {
   name: 'delete_page',
-  description: 'Delete a page/document from Productive.io.',
+  description: 'Delete a page/document from Productive.io. Requires confirmation: the first call only reports what would be deleted, and nothing is removed until you call again with "confirm": true.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -454,6 +461,7 @@ export const deletePageDefinition = {
         type: 'string',
         description: 'ID of the page to delete (required)',
       },
+      confirm: confirmProperty,
     },
     required: ['page_id'],
   },

--- a/src/tools/task-dependencies.ts
+++ b/src/tools/task-dependencies.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { toMcpError } from '../utils/errors.js';
+import { confirmField, confirmProperty, deletionPreview, excerpt } from '../utils/confirm.js';
 import { ProductiveIncludedResource } from '../api/types.js';
 
 function resolveTaskTitle(taskId: string | undefined, included?: ProductiveIncludedResource[]): string | undefined {
@@ -38,6 +40,7 @@ const createTaskDependencySchema = z.object({
 
 const deleteTaskDependencySchema = z.object({
   dependency_id: z.string().min(1, 'Dependency ID is required'),
+  confirm: confirmField,
 });
 
 // ---- Handlers ----
@@ -162,6 +165,21 @@ export async function deleteTaskDependencyTool(
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = deleteTaskDependencySchema.parse(args);
+    if (!params.confirm) {
+      // Fetching first means a wrong ID fails here, before anything is destroyed.
+      const { data: record } = await client.getTaskDependency(params.dependency_id);
+      return deletionPreview({
+        tool: 'delete_task_dependency',
+        kind: 'task dependency',
+        id: params.dependency_id,
+        details: [
+          `Task ID: ${record.relationships?.task?.data?.id ?? 'unknown'}`,
+          `Dependent task ID: ${record.relationships?.dependent_task?.data?.id ?? 'unknown'}`,
+          `Type: ${dependencyTypeLabel(record.attributes.type_id)}`,
+        ],
+      });
+    }
+
     await client.deleteTaskDependency(params.dependency_id);
 
     return {
@@ -171,10 +189,7 @@ export async function deleteTaskDependencyTool(
       }],
     };
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new McpError(ErrorCode.InvalidParams, `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`);
-    }
-    throw new McpError(ErrorCode.InternalError, error instanceof Error ? error.message : 'Unknown error occurred');
+    throw toMcpError(error);
   }
 }
 
@@ -243,7 +258,7 @@ export const createTaskDependencyDefinition = {
 
 export const deleteTaskDependencyDefinition = {
   name: 'delete_task_dependency',
-  description: 'Delete a task dependency by ID.',
+  description: 'Delete a task dependency by ID. Requires confirmation: the first call only reports what would be deleted, and nothing is removed until you call again with "confirm": true.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -251,6 +266,7 @@ export const deleteTaskDependencyDefinition = {
         type: 'string',
         description: 'ID of the task dependency to delete (required)',
       },
+      confirm: confirmProperty,
     },
     required: ['dependency_id'],
   },

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { toMcpError } from '../utils/errors.js';
+import { confirmField, confirmProperty, deletionPreview } from '../utils/confirm.js';
 import { ProductiveTaskUpdate, ProductiveIncludedResource } from '../api/types.js';
 import { formatAttachments } from '../utils/attachments.js';
 
@@ -740,6 +741,7 @@ export const updateTaskDetailsDefinition = {
 
 const deleteTaskSchema = z.object({
   task_id: z.string().min(1, 'Task ID is required'),
+  confirm: confirmField,
 });
 
 export async function deleteTaskTool(
@@ -748,6 +750,24 @@ export async function deleteTaskTool(
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = deleteTaskSchema.parse(args);
+
+    if (!params.confirm) {
+      // Fetching first means a wrong ID fails here, before anything is destroyed.
+      const { data: task } = await client.getTask(params.task_id, 'assignee,workflow_status');
+      return deletionPreview({
+        tool: 'delete_task',
+        kind: 'task',
+        id: params.task_id,
+        details: [
+          `Title: ${task.attributes.title}`,
+          task.attributes.task_number ? `Task number: ${task.attributes.task_number}` : undefined,
+          task.relationships?.project?.data?.id
+            ? `Project ID: ${task.relationships.project.data.id}`
+            : undefined,
+          task.attributes.closed === false ? 'Status: open' : undefined,
+        ],
+      });
+    }
 
     await client.deleteTask(params.task_id);
 
@@ -758,23 +778,13 @@ export async function deleteTaskTool(
       }],
     };
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
-      );
-    }
-
-    throw new McpError(
-      ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
+    throw toMcpError(error);
   }
 }
 
 export const deleteTaskDefinition = {
   name: 'delete_task',
-  description: 'Delete a task from Productive.io by its ID',
+  description: 'Delete a task from Productive.io by its ID. Requires confirmation: the first call only reports what would be deleted, and nothing is removed until you call again with "confirm": true.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -782,6 +792,7 @@ export const deleteTaskDefinition = {
         type: 'string',
         description: 'The ID of the task to delete (required)',
       },
+      confirm: confirmProperty,
     },
     required: ['task_id'],
   },

--- a/src/tools/todos.ts
+++ b/src/tools/todos.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { toMcpError } from '../utils/errors.js';
+import { confirmField, confirmProperty, deletionPreview, excerpt } from '../utils/confirm.js';
 
 // ---- Schemas ----
 
@@ -31,6 +33,7 @@ const updateTodoSchema = z.object({
 
 const deleteTodoSchema = z.object({
   todo_id: z.string().min(1, 'Todo ID is required'),
+  confirm: confirmField,
 });
 
 // ---- Handlers ----
@@ -237,22 +240,28 @@ export async function deleteTodoTool(
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     const params = deleteTodoSchema.parse(args);
+    if (!params.confirm) {
+      // Fetching first means a wrong ID fails here, before anything is destroyed.
+      const { data: record } = await client.getTodo(params.todo_id);
+      return deletionPreview({
+        tool: 'delete_todo',
+        kind: 'todo',
+        id: params.todo_id,
+        details: [
+          `Description: ${record.attributes.description}`,
+          record.attributes.closed ? 'Status: closed' : 'Status: open',
+          record.attributes.due_date ? `Due: ${record.attributes.due_date}` : undefined,
+        ],
+      });
+    }
+
     await client.deleteTodo(params.todo_id);
 
     return {
       content: [{ type: 'text', text: `Todo ${params.todo_id} deleted successfully.` }],
     };
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
-      );
-    }
-    throw new McpError(
-      ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
+    throw toMcpError(error);
   }
 }
 
@@ -357,7 +366,7 @@ export const updateTodoDefinition = {
 
 export const deleteTodoDefinition = {
   name: 'delete_todo',
-  description: 'Delete a todo from Productive.io.',
+  description: 'Delete a todo from Productive.io. Requires confirmation: the first call only reports what would be deleted, and nothing is removed until you call again with "confirm": true.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -365,6 +374,7 @@ export const deleteTodoDefinition = {
         type: 'string',
         description: 'ID of the todo to delete (required)',
       },
+      confirm: confirmProperty,
     },
     required: ['todo_id'],
   },

--- a/src/utils/confirm.ts
+++ b/src/utils/confirm.ts
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview The two-step confirmation gate used by every destructive tool.
+ *
+ * Annotations tell a client that a tool is destructive, but the SDK is explicit that they are
+ * hints and not a security boundary, so a client is free to ignore them. This gate does not
+ * depend on the client honouring anything: the first call performs no deletion at all, it
+ * describes the target and stops. Nothing is removed until a second call arrives carrying
+ * `confirm: true`.
+ *
+ * The description matters as much as the gate. Confirming a bare ID confirms nothing, so the
+ * preview names what is about to be destroyed, which also means a wrong ID is caught by the
+ * lookup before anything is deleted rather than after.
+ *
+ * @module utils/confirm
+ */
+
+import { z } from 'zod';
+
+/** The `confirm` flag, identical across every gated tool. */
+export const confirmField = z.boolean().optional().default(false);
+
+/** The JSON Schema counterpart, for a tool's inputSchema. */
+export const confirmProperty = {
+  type: 'boolean',
+  description:
+    'Set to true to actually delete. Call without it first to see what would be deleted.',
+  default: false,
+} as const;
+
+/** What a caller is about to destroy. */
+export interface DeletionTarget {
+  /** The tool to call again, e.g. `delete_task`. */
+  tool: string;
+  /** The noun for this record, e.g. `task`. */
+  kind: string;
+  /** The record's ID. */
+  id: string;
+  /** Identifying lines, e.g. `Title: Fix the thing`. Empty entries are dropped. */
+  details: Array<string | undefined>;
+}
+
+/**
+ * Build the preview returned by an unconfirmed destructive call.
+ *
+ * Deliberately does not claim the deletion is irreversible in Productive itself, which is not
+ * verified here. It states the checkable fact instead: this server offers no way back.
+ *
+ * @param target - What would be deleted.
+ * @returns The tool result to return in place of deleting.
+ */
+export function deletionPreview(target: DeletionTarget): {
+  content: Array<{ type: string; text: string }>;
+} {
+  const details = target.details.filter((d): d is string => Boolean(d));
+
+  const text = [
+    `Nothing has been deleted yet. This is a preview.`,
+    ``,
+    `About to delete ${target.kind} ${target.id}:`,
+    ...details.map(d => `  ${d}`),
+    ``,
+    `This server has no tool to restore a deleted ${target.kind}.`,
+    ``,
+    `To go ahead, call ${target.tool} again with the same arguments plus "confirm": true.`,
+  ].join('\n');
+
+  return { content: [{ type: 'text', text }] };
+}
+
+/**
+ * Shorten a body for a one-line preview, collapsing whitespace and stripping HTML tags.
+ *
+ * Productive comment and page bodies are HTML, so the raw value is unreadable in a preview.
+ *
+ * @param body - The raw body, possibly HTML or null.
+ * @param max - Maximum length before truncation.
+ * @returns A single-line excerpt, or undefined if there was nothing to show.
+ */
+export function excerpt(body: string | null | undefined, max = 120): string | undefined {
+  if (!body) return undefined;
+  const flat = body.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!flat) return undefined;
+  return flat.length > max ? `${flat.slice(0, max)}...` : flat;
+}


### PR DESCRIPTION
## Why

`create_time_entry` was the only tool in the server that asked before acting. All five deletes
fired immediately, against a production Productive org.

#34 added `destructiveHint`, but the SDK is explicit that annotations are **hints**, not a
security boundary, and a client is free to ignore them. This gate does not rely on the client
honouring anything: the first call performs no deletion at all.

## How it works

First call looks the record up, describes it, and stops. Nothing is removed until a second
call arrives carrying `"confirm": true`.

```
Nothing has been deleted yet. This is a preview.

About to delete task 19300600:
  Title: Suspended members getting emails/notices
  Task number: 407
  Status: open

This server has no tool to restore a deleted task.

To go ahead, call delete_task again with the same arguments plus "confirm": true.
```

**Describing the target is the point.** Confirming a bare ID confirms nothing, so the preview
names what is about to be destroyed. Looking it up first has a second benefit: a wrong ID
fails at preview time, before anything is destroyed, instead of successfully deleting the
wrong record.

Gated: `delete_task`, `delete_comment`, `delete_page`, `delete_todo`,
`delete_task_dependency`. Matches the existing `create_time_entry` pattern, with `confirm`
defaulting to false and never `required`, so the safe path is the default rather than
something to opt into.

## Scope decisions

- **Archives are deliberately not gated.** `archive_folder` and `archive_task_list` have
  `restore_*` counterparts, so they are recoverable. Gating them would train people to click
  through the prompt, which makes the real ones less effective.
- **The four non-task delete tools also move onto `toMcpError`.** Not drive-by tidying: the
  gate's "a bad ID is caught at preview" property is only real if a 404 surfaces as
  `InvalidParams` rather than being collapsed into `InternalError`. `delete_task` already went
  through the helper from #33.
- **The preview claims only what is checkable.** It says *this server* has no tool to restore
  the record, rather than asserting Productive itself cannot, which is not verified here.

## Tests

Table-driven across all five tools. The assertion that matters is not that a preview comes
back, it is that the delete method is **never reached** without confirmation:

- no delete when `confirm` is omitted, and none when it is explicitly `false`
- the preview describes the record rather than echoing the ID back
- deletes exactly once when `confirm: true`
- confirming skips the lookup, so the gate costs no extra call on the second pass
- a 404 at preview time surfaces as `InvalidParams` and still calls no delete
- each definition advertises `confirm` and does not mark it `required`

## Verification

Against the live API, an unconfirmed `delete_task` on real task 19300600 returned the preview,
and a follow-up `get_task_overview` confirmed the task is still there.

177 tests passing, type-check clean, smoke test passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)