### PR TITLE
docs: rewrite CLAUDE.md to describe this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,741 +1,117 @@
 # CLAUDE.md
 
-This file provides comprehensive guidance to Claude Code when working with Next.js 15 applications with React 19 and TypeScript.
+An MCP server exposing the Productive.io API over stdio. Plain TypeScript compiled to ESM
+and run under Node. **No React, no Next.js, no JSX, no browser, no bundler.** If you find
+yourself reaching for a UI convention here, you are in the wrong repo.
 
-## Core Development Philosophy
-
-### KISS (Keep It Simple, Stupid)
-
-Simplicity should be a key goal in design. Choose straightforward solutions over complex ones whenever possible. Simple solutions are easier to understand, maintain, and debug.
-
-### YAGNI (You Aren't Gonna Need It)
-
-Avoid building functionality on speculation. Implement features only when they are needed, not when you anticipate they might be useful in the future.
-
-### Design Principles
-
-- **Dependency Inversion**: High-level modules should not depend on low-level modules. Both should depend on abstractions.
-- **Open/Closed Principle**: Software entities should be open for extension but closed for modification.
-- **Vertical Slice Architecture**: Organize by features, not layers
-- **Component-First**: Build with reusable, composable components with single responsibility
-- **Fail Fast**: Validate inputs early, throw errors immediately
-
-## 🤖 AI Assistant Guidelines
-
-### Context Awareness
-
-- When implementing features, always check existing patterns first
-- Prefer composition over inheritance in all designs
-- Use existing utilities before creating new ones
-- Check for similar functionality in other domains/features
-
-### Common Pitfalls to Avoid
-
-- Creating duplicate functionality
-- Overwriting existing tests
-- Modifying core frameworks without explicit instruction
-- Adding dependencies without checking existing alternatives
-
-### Workflow Patterns
-
-- Preferably create tests BEFORE implementation (TDD)
-- Use "think hard" for architecture decisions
-- Break complex tasks into smaller, testable units
-- Validate understanding before implementation
-
-### Search Command Requirements
-
-**CRITICAL**: Always use `rg` (ripgrep) instead of traditional `grep` and `find` commands:
+## Commands
 
 ```bash
-# ❌ Don't use grep
-grep -r "pattern" .
-
-# ✅ Use rg instead
-rg "pattern"
-
-# ❌ Don't use find with name
-find . -name "*.tsx"
-
-# ✅ Use rg with file filtering
-rg --files | rg "\.tsx$"
-# or
-rg --files -g "*.tsx"
+npm test              # vitest, the real number (see the vitest.config.ts note below)
+npm run type-check    # tsc --noEmit
+npm run build         # tsc + chmod, emits build/
+npm run dev           # tsc --watch
+node scripts/smoke-test.mjs   # start the built server, assert the surface it serves
 ```
 
-**Enforcement Rules:**
+CI runs type-check, test, build and the smoke test on Node 20 and 22, plus a Node 18 job that
+runs the built output on the lowest version `engines` allows. Run all four locally before
+pushing.
 
-```
-(
-    r"^grep\b(?!.*\|)",
-    "Use 'rg' (ripgrep) instead of 'grep' for better performance and features",
-),
-(
-    r"^find\s+\S+\s+-name\b",
-    "Use 'rg --files | rg pattern' or 'rg --files -g pattern' instead of 'find -name' for better performance",
-),
-```
-
-## 🧱 Code Structure & Modularity
-
-### File and Component Limits
-
-- **Never create a file longer than 500 lines of code.** If approaching this limit, refactor by splitting into modules or helper files.
-- **Components should be under 200 lines** for better maintainability.
-- **Functions should be short and focused sub 50 lines** and have a single responsibility.
-- **Organize code into clearly separated modules**, grouped by feature or responsibility.
-
-## 🚀 Next.js 15 & React 19 Key Features
-
-### Next.js 15 Core Features
-
-- **Turbopack**: Fast bundler for development (stable)
-- **App Router**: File-system based router with layouts and nested routing
-- **Server Components**: React Server Components for performance
-- **Server Actions**: Type-safe server functions
-- **Parallel Routes**: Concurrent rendering of multiple pages
-- **Intercepting Routes**: Modal-like experiences
-
-### React 19 Features
-
-- **React Compiler**: Eliminates need for `useMemo`, `useCallback`, and `React.memo`
-- **Actions**: Handle async operations with built-in pending states
-- **use() API**: Simplified data fetching and context consumption
-- **Document Metadata**: Native support for SEO tags
-- **Enhanced Suspense**: Better loading states and error boundaries
-
-### TypeScript Integration (MANDATORY)
-
-- **MUST use `ReactElement` instead of `JSX.Element`** for return types
-- **MUST import types from 'react'** explicitly
-- **NEVER use `JSX.Element` namespace** - use React types directly
-
-```typescript
-// ✅ CORRECT: Modern React 19 typing
-import { ReactElement } from "react";
-
-function MyComponent(): ReactElement {
-  return <div>Content</div>;
-}
-
-// ❌ FORBIDDEN: Legacy JSX namespace
-function MyComponent(): JSX.Element {
-  // Cannot find namespace 'JSX'
-  return <div>Content</div>;
-}
-```
-
-## 🏗️ Project Structure (Vertical Slice Architecture)
+## Architecture
 
 ```
 src/
-├── app/                   # Next.js App Router
-│   ├── (routes)/          # Route groups
-│   ├── globals.css        # Global styles
-│   ├── layout.tsx         # Root layout
-│   └── page.tsx           # Home page
-├── components/            # Shared UI components
-│   ├── ui/                # Base components (shadcn/ui)
-│   └── common/            # Application-specific shared components
-├── features/              # Feature-based modules (RECOMMENDED)
-│   └── [feature]/
-│       ├── __tests__/     # Co-located tests
-│       ├── components/    # Feature components
-│       ├── hooks/         # Feature-specific hooks
-│       ├── api/           # API integration
-│       ├── schemas/       # Zod validation schemas
-│       ├── types/         # TypeScript types
-│       └── index.ts       # Public API
-├── lib/                   # Core utilities and configurations
-│   ├── utils.ts           # Utility functions
-│   ├── env.ts             # Environment validation
-│   └── constants.ts       # Application constants
-├── hooks/                 # Shared custom hooks
-├── styles/                # Styling files
-└── types/                 # Shared TypeScript types
+├── index.ts          # entry point, calls createServer()
+├── server.ts         # tool registry + the CallTool switch. Every tool is wired here.
+├── server-instructions.ts  # SERVER_INFO + the instructions clients surface
+├── api/
+│   ├── client.ts     # ProductiveAPIClient: ALL HTTP goes through this
+│   └── types.ts      # JSON:API response shapes
+├── tools/            # one file per domain (tasks, comments, pages, todos, ...)
+│   └── annotations.ts  # the behaviour-hint table for all 72 tools
+├── utils/            # errors.ts, confirm.ts, attachments.ts, html.ts, mentions.ts
+├── config/           # env validation
+└── prompts/
 ```
 
-## 🎯 TypeScript Configuration (STRICT REQUIREMENTS)
+**The client/tool split is the main rule.** `src/api/client.ts` owns every HTTP call.
+Tools parse arguments, call a client method, and format text. A tool must never call `fetch`
+directly: doing so bypasses the JSON:API error diagnostics and produces an opaque
+`statusText`. A test in `src/tools/__tests__/task-tools-client.test.ts` fails the build if any
+file under `src/tools` calls `fetch`.
 
-### MUST Follow These Compiler Options
+### Adding a tool
 
-```json
-{
-  "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "es6"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "plugins": [{ "name": "next" }],
-    "baseUrl": ".",
-    "paths": { "@/*": ["./src/*"] }
-  },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
-}
-```
+Four places, all required:
 
-### MANDATORY Type Requirements
+1. A handler and a `*Definition` object in the relevant `src/tools/*.ts`.
+2. A client method in `src/api/client.ts` if it needs a new endpoint.
+3. The definition in `toolDefinitions` **and** a `case` in the `CallToolRequestSchema` switch
+   in `src/server.ts`. Missing the switch case registers a tool that cannot be called.
+4. An entry in `TOOL_ANNOTATIONS` (`src/tools/annotations.ts`). A test fails if a registered
+   tool has no entry, and vice versa.
 
-- **NEVER use `any` type** - use `unknown` if type is truly unknown
-- **MUST have explicit return types** for all functions and components
-- **MUST use proper generic constraints** for reusable components
-- **MUST use type inference from Zod schemas** using `z.infer<typeof schema>`
-- **NEVER use `@ts-ignore`** or `@ts-expect-error` - fix the type issue properly
+Each schema is written twice: Zod for runtime validation, and a hand-written JSON Schema
+literal in the definition. Nothing enforces that they agree, so change both together.
 
-## 📦 Package Management & Dependencies
+## Gotchas
 
-### Essential Next.js 15 Dependencies
+**The MCP client runs `build/`, not `src/`.** Nothing watches. After any change you must
+`npm run build` and restart the MCP connection, or you are silently testing the previous
+compile.
 
-```json
-{
-  "dependencies": {
-    "next": "^15.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "typescript": "^5.0.0"
-  },
-  "devDependencies": {
-    "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
-    "eslint": "^8",
-    "eslint-config-next": "15.0.0",
-    "prettier": "^3.0.0",
-    "tailwindcss": "^3.4.0",
-    "postcss": "^8.4.0",
-    "autoprefixer": "^10.4.0"
-  }
-}
-```
+**`instructions` goes in ServerOptions, the second `new Server(...)` argument.** A
+`description` key on the first argument (the `Implementation` object) is not an MCP field and
+is silently discarded. That bug shipped once and meant the server delivered no guidance at all
+for months. See `src/server-instructions.ts`.
 
-### Recommended Additional Dependencies
+**A relationship you did not `include` comes back as `{"meta": {"included": false}}`,** not
+as `{"data": ...}`. Reading a relationship you did not request returns nothing, silently.
 
-```bash
-# UI and Styling
-npm install @radix-ui/react-* class-variance-authority clsx tailwind-merge
+**`vitest.config.ts` exists to stop vitest collecting `build/`.** Without it the compiled
+copies of every test are collected too, roughly doubling the reported count and letting a
+stale build keep an edited test passing. Do not pass `--dir src`: it conflicts with the
+config's `include` and finds nothing. Just run `npm test`.
 
-# Form Handling and Validation
-npm install react-hook-form @hookform/resolvers zod
+**Force-push is blocked on the dev box.** To bring a branch up to date, merge `main` into it.
+Do not plan around a rebase.
 
-# State Management (when needed)
-npm install @tanstack/react-query zustand
+**`.env` holds a live token for a production Productive org, not a sandbox.** Prefer
+read-only calls when testing against the real API. Destructive tools are gated (below), but
+the gate is a speed bump, not authorisation.
 
-# Development Tools
-npm install -D @testing-library/react @testing-library/jest-dom vitest jsdom
-```
+## Conventions
 
-## 🛡️ Data Validation with Zod (MANDATORY FOR ALL EXTERNAL DATA)
+- Destructive tools take `confirm` (defaulting to false, never `required`). The first call
+  looks the record up, describes it, and returns without deleting. See `src/utils/confirm.ts`.
+- Errors go through `toMcpError` (`src/utils/errors.ts`): 400, 404 and 422 become
+  `InvalidParams`, everything else `InternalError`. `time-entries.ts` still has its own inline
+  422 check and is the last holdout.
+- Tool descriptions carry cross-tool routing where it matters, but a description cannot
+  express "call A before B", because a model weighs each one alone and the literal name match
+  wins. Server-level routing rules belong in `server-instructions.ts`.
+- Comment and description bodies are HTML. Mentions are inline JSON blobs (`@[{...}]`);
+  `src/utils/mentions.ts` renders them.
+- Semantic commits: `feat:`, `fix:`, `refactor:`, `test:`, `ci:`, `chore:`.
 
-### MUST Follow These Validation Rules
+## Testing
 
-- **MUST validate ALL external data**: API responses, form inputs, URL params, environment variables
-- **MUST use branded types**: For all IDs and domain-specific values
-- **MUST fail fast**: Validate at system boundaries, throw errors immediately
-- **MUST use type inference**: Always derive TypeScript types from Zod schemas
+Vitest, no DOM, no React Testing Library. Tests sit in `__tests__` folders beside the code.
 
-### Schema Example (MANDATORY PATTERNS)
+Mock at the right layer. Tool tests mock `ProductiveAPIClient` wholesale, which pins what a
+tool *asks for* but never what the client *sends*, so client URL building needs its own tests
+stubbing `global.fetch` (`src/api/__tests__/client-requests.test.ts`). Mutation-test anything
+load-bearing: break the thing on purpose and confirm a test goes red. A green suite proved
+nothing when a query parameter was renamed to garbage.
 
-```typescript
-import { z } from "zod";
+Tests must pass with no credentials. CI runs them with none, deliberately.
 
-// MUST use branded types for ALL IDs
-const UserIdSchema = z.string().uuid().brand<"UserId">();
-type UserId = z.infer<typeof UserIdSchema>;
+## Environment
 
-// Environment validation (REQUIRED)
-export const envSchema = z.object({
-  NODE_ENV: z.enum(["development", "test", "production"]),
-  NEXT_PUBLIC_APP_URL: z.string().url(),
-  DATABASE_URL: z.string().min(1),
-  NEXTAUTH_SECRET: z.string().min(1),
-  NEXTAUTH_URL: z.string().url(),
-});
+`PRODUCTIVE_API_TOKEN` and `PRODUCTIVE_ORG_ID` are required. `PRODUCTIVE_USER_ID` (enables
+the `"me"` shorthand), `PRODUCTIVE_API_BASE_URL` and `PRODUCTIVE_ATTACHMENT_DIR` are optional.
 
-export const env = envSchema.parse(process.env);
-
-// API response validation
-export const apiResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
-  z.object({
-    success: z.boolean(),
-    data: dataSchema,
-    error: z.string().optional(),
-    timestamp: z.string().datetime(),
-  });
-```
-
-### Form Validation with React Hook Form
-
-```typescript
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-
-const formSchema = z.object({
-  email: z.string().email(),
-  username: z.string().min(3).max(20),
-});
-
-type FormData = z.infer<typeof formSchema>;
-
-function UserForm(): ReactElement {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors, isSubmitting },
-  } = useForm<FormData>({
-    resolver: zodResolver(formSchema),
-    mode: "onBlur",
-  });
-
-  const onSubmit = async (data: FormData): Promise<void> => {
-    // Handle validated data
-  };
-
-  return <form onSubmit={handleSubmit(onSubmit)}>{/* Form fields */}</form>;
-}
-```
-
-## 🧪 Testing Strategy (MANDATORY REQUIREMENTS)
-
-### MUST Meet These Testing Standards
-
-- **MINIMUM 80% code coverage** - NO EXCEPTIONS
-- **MUST co-locate tests** with components in `__tests__` folders
-- **MUST use React Testing Library** for all component tests
-- **MUST test user behavior** not implementation details
-- **MUST mock external dependencies** appropriately
-
-### Test Configuration (Vitest + React Testing Library)
-
-```typescript
-// vitest.config.ts
-import { defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react";
-import { resolve } from "path";
-
-export default defineConfig({
-  plugins: [react()],
-  test: {
-    environment: "jsdom",
-    setupFiles: ["./src/test/setup.ts"],
-    coverage: {
-      reporter: ["text", "json", "html"],
-      threshold: {
-        global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
-      },
-    },
-  },
-  resolve: {
-    alias: {
-      "@": resolve(__dirname, "./src"),
-    },
-  },
-});
-```
-
-### Test Example (WITH MANDATORY DOCUMENTATION)
-
-```typescript
-/**
- * @fileoverview Tests for UserProfile component
- * @module components/__tests__/UserProfile.test
- */
-
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, userEvent } from "@testing-library/react";
-import { UserProfile } from "../UserProfile";
-
-/**
- * Test suite for UserProfile component.
- *
- * Tests user interactions, state management, and error handling.
- * Mocks external dependencies to ensure isolated unit tests.
- */
-describe("UserProfile", () => {
-  /**
-   * Tests that user name updates correctly on form submission.
-   */
-  it("should update user name on form submission", async () => {
-    const user = userEvent.setup();
-    const onUpdate = vi.fn();
-
-    render(<UserProfile onUpdate={onUpdate} />);
-
-    const input = screen.getByLabelText(/name/i);
-    await user.type(input, "John Doe");
-    await user.click(screen.getByRole("button", { name: /save/i }));
-
-    expect(onUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ name: "John Doe" })
-    );
-  });
-});
-```
-
-## 🎨 Component Guidelines (STRICT REQUIREMENTS)
-
-### MANDATORY Component Documentation
-
-````typescript
-/**
- * Button component with multiple variants and sizes.
- *
- * Provides a reusable button with consistent styling and behavior
- * across the application. Supports keyboard navigation and screen readers.
- *
- * @component
- * @example
- * ```tsx
- * <Button
- *   variant="primary"
- *   size="medium"
- *   onClick={handleSubmit}
- * >
- *   Submit Form
- * </Button>
- * ```
- */
-interface ButtonProps {
-  /** Visual style variant of the button */
-  variant: "primary" | "secondary";
-
-  /** Size of the button @default 'medium' */
-  size?: "small" | "medium" | "large";
-
-  /** Click handler for the button */
-  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
-
-  /** Content to be rendered inside the button */
-  children: React.ReactNode;
-
-  /** Whether the button is disabled @default false */
-  disabled?: boolean;
-}
-
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ variant, size = "medium", onClick, children, disabled = false }, ref) => {
-    return (
-      <button
-        ref={ref}
-        className={cn(buttonVariants({ variant, size }))}
-        onClick={onClick}
-        disabled={disabled}
-      >
-        {children}
-      </button>
-    );
-  }
-);
-Button.displayName = "Button";
-````
-
-### Shadcn/UI Component Pattern (RECOMMENDED)
-
-```typescript
-"use client";
-
-import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
-import { cn } from "@/lib/utils";
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
-  {
-    variants: {
-      variant: {
-        default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-);
-
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
-}
-
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    return (
-      <button
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
-);
-Button.displayName = "Button";
-
-export { Button, buttonVariants };
-```
-
-## 🔄 State Management (STRICT HIERARCHY)
-
-### MUST Follow This State Hierarchy
-
-1. **Local State**: `useState` ONLY for component-specific state
-2. **Context**: For cross-component state within a single feature
-3. **URL State**: MUST use search params for shareable state
-4. **Server State**: MUST use TanStack Query for ALL API data
-5. **Global State**: Zustand ONLY when truly needed app-wide
-
-### Server State Pattern (TanStack Query)
-
-```typescript
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-
-function useUser(id: UserId) {
-  return useQuery({
-    queryKey: ["user", id],
-    queryFn: async () => {
-      const response = await fetch(`/api/users/${id}`);
-
-      if (!response.ok) {
-        throw new ApiError("Failed to fetch user", response.status);
-      }
-
-      const data = await response.json();
-      return userSchema.parse(data);
-    },
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    retry: 3,
-  });
-}
-
-function useUpdateUser() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async (userData: UpdateUserData) => {
-      const response = await fetch("/api/users", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(userData),
-      });
-
-      if (!response.ok) {
-        throw new ApiError("Failed to update user", response.status);
-      }
-
-      return response.json();
-    },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ["user"] });
-    },
-  });
-}
-```
-
-## 🔐 Security Requirements (MANDATORY)
-
-### Input Validation (MUST IMPLEMENT ALL)
-
-- **MUST sanitize ALL user inputs** with Zod before processing
-- **MUST validate file uploads**: type, size, and content
-- **MUST prevent XSS** with proper escaping
-- **MUST implement CSRF protection** for forms
-- **NEVER use dangerouslySetInnerHTML** without sanitization
-
-### Environment Variables (MUST VALIDATE)
-
-```typescript
-// lib/env.ts
-import { z } from "zod";
-
-const envSchema = z.object({
-  NODE_ENV: z.enum(["development", "test", "production"]),
-  NEXT_PUBLIC_APP_URL: z.string().url(),
-  DATABASE_URL: z.string().min(1),
-  NEXTAUTH_SECRET: z.string().min(32),
-  NEXTAUTH_URL: z.string().url(),
-});
-
-export const env = envSchema.parse(process.env);
-```
-
-## 🚀 Performance Guidelines
-
-### Next.js 15 Optimizations
-
-- **Use Server Components** by default for data fetching
-- **Client Components** only when necessary (interactivity)
-- **Dynamic imports** for large client components
-- **Image optimization** with next/image
-- **Font optimization** with next/font
-
-### Bundle Optimization
-
-```typescript
-// next.config.js
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    turbo: {
-      // Turbopack configuration
-    },
-  },
-  images: {
-    formats: ["image/webp", "image/avif"],
-  },
-  // Bundle analyzer
-  webpack: (config, { dev, isServer }) => {
-    if (!dev && !isServer) {
-      config.optimization.splitChunks.chunks = "all";
-    }
-    return config;
-  },
-};
-
-module.exports = nextConfig;
-```
-
-## 💅 Code Style & Quality
-
-### ESLint Configuration (MANDATORY)
-
-```javascript
-// eslint.config.js
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
-
-const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
-  {
-    rules: {
-      "@typescript-eslint/no-explicit-any": "error",
-      "@typescript-eslint/explicit-function-return-type": "error",
-      "no-console": ["error", { allow: ["warn", "error"] }],
-      "react/function-component-definition": [
-        "error",
-        {
-          namedComponents: "arrow-function",
-        },
-      ],
-    },
-  },
-];
-
-export default eslintConfig;
-```
-
-## 📋 Development Commands
-
-```json
-{
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint --max-warnings 0",
-    "lint:fix": "next lint --fix",
-    "test": "vitest",
-    "test:watch": "vitest --watch",
-    "test:coverage": "vitest --coverage",
-    "test:ui": "vitest --ui",
-    "type-check": "tsc --noEmit",
-    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
-    "validate": "npm run type-check && npm run lint && npm run test:coverage"
-  }
-}
-```
-
-## ⚠️ CRITICAL GUIDELINES (MUST FOLLOW ALL)
-
-1. **ENFORCE strict TypeScript** - ZERO compromises on type safety
-2. **VALIDATE everything with Zod** - ALL external data must be validated
-3. **MINIMUM 80% test coverage** - NO EXCEPTIONS
-4. **MUST co-locate related files** - Tests MUST be in `__tests__` folders
-5. **MAXIMUM 500 lines per file** - Split if larger
-6. **MAXIMUM 200 lines per component** - Refactor if larger
-7. **MUST handle ALL states** - Loading, error, empty, and success
-8. **MUST use semantic commits** - feat:, fix:, docs:, refactor:, test:
-9. **MUST write complete JSDoc** - ALL exports must be documented
-10. **NEVER use `any` type** - Use proper typing or `unknown`
-11. **MUST pass ALL automated checks** - Before ANY merge
-
-## 📋 Pre-commit Checklist (MUST COMPLETE ALL)
-
-- [ ] TypeScript compiles with ZERO errors (`npm run type-check`)
-- [ ] Tests written and passing with 80%+ coverage (`npm run test:coverage`)
-- [ ] ESLint passes with ZERO warnings (`npm run lint`)
-- [ ] Prettier formatting applied (`npm run format`)
-- [ ] All components have complete JSDoc documentation
-- [ ] Zod schemas validate ALL external data
-- [ ] ALL states handled (loading, error, empty, success)
-- [ ] Error boundaries implemented for features
-- [ ] Accessibility requirements met (ARIA labels, keyboard nav)
-- [ ] No console.log statements in production code
-- [ ] Environment variables validated with Zod
-- [ ] Component files under 200 lines
-- [ ] No prop drilling beyond 2 levels
-- [ ] Server/Client components used appropriately
-
-### FORBIDDEN Practices
-
-- **NEVER use `any` type** (except library declaration merging with comments)
-- **NEVER skip tests** for new functionality
-- **NEVER ignore TypeScript errors** with `@ts-ignore`
-- **NEVER trust external data** without Zod validation
-- **NEVER use `JSX.Element`** - use `ReactElement` instead
-- **NEVER store sensitive data** in localStorage or client state
-- **NEVER use dangerouslySetInnerHTML** without sanitization
-- **NEVER exceed file/component size limits**
-- **NEVER prop drill** beyond 2 levels - use context or state management
-- **NEVER commit** without passing all quality checks
-
----
-
-_This guide is optimized for Next.js 15 with React 19. Keep it updated as frameworks evolve._
-_Focus on type safety, performance, and maintainability in all development decisions._
-_Last updated: January 2025_
+`"me"` is resolved per-tool, not centrally. Only `create_task`, `update_task_assignment`,
+`create_time_entry` and `list_time_entries` honour it. `list_tasks` forwards `assignee_id`
+straight to the API, so `"me"` there is not a filter. Use `my_tasks` to list your own tasks.


### PR DESCRIPTION
## The audit

| Criterion | Score | Notes |
|---|---|---|
| Commands/workflows | 0/20 | Documented `next dev`, `next build`, `next lint`. None exist. |
| Architecture clarity | 0/20 | Described `src/app/`, route groups, Server Components. |
| Non-obvious patterns | 0/15 | No gotchas at all. |
| Conciseness | 3/15 | 741 lines, 62 of them referencing React/Next/JSX. |
| Currency | 0/15 | Zero mentions of MCP, Productive or stdio. |
| Actionability | 5/15 | Executable, but for a different project. |

**8/100.** The file was not merely stale, it was **actively misleading**: it mandated
`ReactElement` over `JSX.Element` in a repo with no `.tsx` files, required React Testing
Library and an 80% coverage threshold that does not exist, and prescribed `tsconfig` options
(`noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `noUnusedLocals`) that are **not**
set here. A session following it would work to satisfy rules that cannot apply while missing
every rule that does. That is worse than no file.

## What replaced it

117 lines. The bar for inclusion was "not derivable from reading the code", so most of it is
what cost time to discover:

- the client/tool split, and the test that fails the build if anything under `src/tools` calls
  `fetch` directly
- the **four** places a new tool must be registered, since missing the `switch` case registers
  a tool that cannot be called
- `instructions` belongs in ServerOptions, not as a `description` on the `Implementation`
  object where the SDK silently discards it
- an un-`include`d relationship returns `{"meta": {"included": false}}` rather than data
- `build/` is what the MCP client runs, so any change needs a build and a connection restart
- why `vitest.config.ts` exists, and that `--dir src` now finds nothing
- force-push is blocked, so merge rather than rebase
- `.env` points at a production org, not a sandbox
- the `confirm`-gate and `toMcpError` conventions
- `"me"` is resolved per-tool, and `list_tasks` does not honour it

## Verification

Every path, command and file reference in the new file was checked to exist: all 4 npm
scripts, all 14 source paths, all 4 directories. The two remaining mentions of React are the
deliberate "this repo is not that" statements.

I also caught one claim that would have rotted, a hard-coded test count, and replaced it with
a description that will not drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)