### PR TITLE
refactor: route time-entries errors through toMcpError

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,12 @@ the gate is a speed bump, not authorisation.
 
 - Destructive tools take `confirm` (defaulting to false, never `required`). The first call
   looks the record up, describes it, and returns without deleting. See `src/utils/confirm.ts`.
-- Errors go through `toMcpError` (`src/utils/errors.ts`): 400, 404 and 422 become
-  `InvalidParams`, everything else `InternalError`. `time-entries.ts` still has its own inline
-  422 check and is the last holdout.
+- Errors should go through `toMcpError` (`src/utils/errors.ts`): 400, 404 and 422 become
+  `InvalidParams`, everything else `InternalError`. This is **partially migrated**. Roughly 70
+  handlers across 19 files still map inline, collapsing everything to `InternalError`, so a
+  bad argument is indistinguishable from a server fault. Files are mixed: a file using
+  `toMcpError` in one tool often still maps inline in another. When you touch a handler,
+  convert it.
 - Tool descriptions carry cross-tool routing where it matters, but a description cannot
   express "call A before B", because a model weighs each one alone and the literal name match
   wins. Server-level routing rules belong in `server-instructions.ts`.

--- a/src/tools/__tests__/time-entries-errors.test.ts
+++ b/src/tools/__tests__/time-entries-errors.test.ts
@@ -59,4 +59,46 @@ describe('createTimeEntryTool - error mapping', () => {
     expect(caught.code).toBe(ErrorCode.InternalError);
     expect(caught.message).toContain('500');
   });
+
+  // This file used to check only for 422 inline, so a bad service_id or task_id came back as
+  // InternalError and read as a server fault rather than a wrong argument.
+  it('maps a 404 to InvalidParams now that it shares toMcpError', async () => {
+    const apiError = new ProductiveApiError(
+      'Record Not Found (404): The requested record was not found',
+      404,
+      [{ status: '404', title: 'Record Not Found' }]
+    );
+
+    let caught: any;
+    try {
+      await createTimeEntryTool(clientThatThrows(apiError), validArgs);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught.code).toBe(ErrorCode.InvalidParams);
+    expect(caught.message).toContain('Record Not Found');
+  });
+
+  it('still refuses to create without confirmation', async () => {
+    const createTimeEntry = vi.fn();
+    const client = { createTimeEntry } as unknown as ProductiveAPIClient;
+
+    const result = await createTimeEntryTool(client, { ...validArgs, confirm: false });
+
+    expect(createTimeEntry).not.toHaveBeenCalled();
+    expect(result.content[0].text).toContain('confirm');
+  });
+
+  it('keeps the "me" rejection as InvalidParams rather than re-wrapping it', async () => {
+    let caught: any;
+    try {
+      await createTimeEntryTool(clientThatThrows(new Error('unused')), { ...validArgs, person_id: 'me' }, {});
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught.code).toBe(ErrorCode.InvalidParams);
+    expect(caught.message).toContain('PRODUCTIVE_USER_ID');
+  });
 });

--- a/src/tools/time-entries.ts
+++ b/src/tools/time-entries.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
-import { ProductiveAPIClient, ProductiveApiError } from '../api/client.js';
+import { ProductiveAPIClient } from '../api/client.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { toMcpError } from '../utils/errors.js';
 import { ProductiveTimeEntryCreate } from '../api/types.js';
 
 // Helper function to parse time input into minutes
@@ -181,17 +182,7 @@ export async function listTimeEntresTool(
       }],
     };
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
-      );
-    }
-    
-    throw new McpError(
-      ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
+    throw toMcpError(error);
   }
 }
 
@@ -370,24 +361,9 @@ ID: ${response.data.id}`;
       }],
     };
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
-      );
-    }
-
-    // A 422 from Productive is a data/validation error (e.g. locked timesheet
-    // period, or a task/service not in an open budget) — surface it as invalid
-    // params with the self-diagnosing message (includes the source.pointer).
-    if (error instanceof ProductiveApiError && error.httpStatus === 422) {
-      throw new McpError(ErrorCode.InvalidParams, error.message);
-    }
-
-    throw new McpError(
-      ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
+    // A 422 here is a data problem (a locked timesheet period, or a task or service not in an
+    // open budget) and becomes InvalidParams, along with 400 and 404. See utils/errors.ts.
+    throw toMcpError(error);
   }
 }
 
@@ -428,17 +404,7 @@ export async function listServicesTool(
       }],
     };
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
-      );
-    }
-    
-    throw new McpError(
-      ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
+    throw toMcpError(error);
   }
 }
 
@@ -487,17 +453,7 @@ export async function getProjectServicesTool(
       }],
     };
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
-      );
-    }
-    
-    throw new McpError(
-      ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
+    throw toMcpError(error);
   }
 }
 
@@ -665,17 +621,7 @@ export async function listProjectDealsTool(
       }],
     };
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
-      );
-    }
-    
-    throw new McpError(
-      ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
+    throw toMcpError(error);
   }
 }
 
@@ -722,17 +668,7 @@ export async function listDealServicesTool(
       }],
     };
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        `Invalid parameters: ${error.errors.map(e => e.message).join(', ')}`
-      );
-    }
-    
-    throw new McpError(
-      ErrorCode.InternalError,
-      error instanceof Error ? error.message : 'Unknown error occurred'
-    );
+    throw toMcpError(error);
   }
 }
 


### PR DESCRIPTION
## What

All six handlers in `time-entries.ts` now use the shared `toMcpError` helper. The file had its
own inline check that mapped **only** 422 to `InvalidParams`, so a 400 or a 404 (a bad
`service_id` or `task_id`) came back as `InternalError` and read as a server fault rather than
a wrong argument.

Left alone deliberately:

- The three inner parse guards for `date`, `time` and `billable_time`. They already throw
  `InvalidParams` with useful messages.
- The `"me"` rejection. `toMcpError` passes an existing `McpError` through unwrapped, so it
  keeps its code.

## A correction you should read

I told you last PR that `time-entries.ts` was **"the last holdout"**, and I wrote that into
CLAUDE.md. **That was wrong.** I only found out by sweeping the codebase after making this
change:

```
files using toMcpError:            8
files still mapping inline:       19
inline handlers still remaining:  71
```

Worse, the files are **mixed**. The earlier PRs (#33, #36) converted only the specific
handlers they touched, so `tasks.ts`, `comments.ts`, `pages.ts`, `todos.ts`, `subtasks.ts` and
`task-dependencies.ts` all use `toMcpError` in one tool while still mapping inline in another.
`task-lists.ts` alone has 18 inline sites.

So the real state is "partially migrated", not "one file left". CLAUDE.md is corrected in this
PR to say exactly that, with a convert-on-touch instruction, rather than leaving a confident
falsehood in the file every future session reads first.

**This PR does not fix the other 71.** That is a much larger change than the one asked for,
and it shifts error codes across the whole tool surface, so it should be your call rather than
something I widen into unannounced. It is mechanical and I am happy to do it as a follow-up.

## Tests

- 404 now maps to `InvalidParams` (the actual behaviour change)
- 500 still maps to `InternalError`
- the confirm gate still blocks an unconfirmed create
- the `"me"` rejection keeps `InvalidParams` rather than being re-wrapped

Mutation-checked: dropping 404 from `CALLER_FAULT_STATUSES` fails the suite.

180 tests passing, type-check clean, smoke test passing.

## One note on process

My first attempt at this used a multi-line regex to rewrite the catch blocks. It over-matched
across a function boundary and deleted `createTimeEntryTool` entirely. I caught it on the
type-check, reverted, and redid it with exact string replacement after verifying the block
count. Flagging it because the final diff looks clean and gives no hint that happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)