### PR TITLE
fix: reposition_task could not move a task to the top or bottom of its list

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -215,7 +215,10 @@ export class ProductiveAPIClient {
     project_id?: string;
     assignee_id?: string;
     parent_task_id?: string;
+    task_list_id?: string;
     status?: 'open' | 'closed';
+    /** JSON:API sort, e.g. `placement` or `-placement` for descending. */
+    sort?: string;
     limit?: number;
     page?: number;
   }): Promise<ProductiveResponse<ProductiveTask>> {
@@ -226,6 +229,14 @@ export class ProductiveAPIClient {
 
     if (params?.project_id) {
       queryParams.append('filter[project_id]', params.project_id);
+    }
+
+    if (params?.task_list_id) {
+      queryParams.append('filter[task_list_id]', params.task_list_id);
+    }
+
+    if (params?.sort) {
+      queryParams.append('sort', params.sort);
     }
 
     if (params?.parent_task_id) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,7 @@ import { listTimeEntresTool, createTimeEntryTool, listServicesTool, getProjectSe
 import { updateTaskSprint, updateTaskSprintTool } from './tools/task-sprint.js';
 import { moveTaskToList, moveTaskToListTool } from './tools/task-list-move.js';
 import { addToBacklog, addToBacklogTool } from './tools/task-backlog.js';
-import { taskRepositionTool, taskRepositionDefinition, taskRepositionSchema } from './tools/task-reposition.js';
+import { taskRepositionTool, taskRepositionDefinition } from './tools/task-reposition.js';
 import { generateTimesheetPrompt, timesheetPromptDefinition, generateQuickTimesheetPrompt, quickTimesheetPromptDefinition } from './prompts/timesheet.js';
 import { listFolders, listFoldersTool, getFolder, getFolderTool, createFolder, createFolderTool, updateFolder, updateFolderTool, archiveFolder, archiveFolderTool, restoreFolder, restoreFolderTool } from './tools/folders.js';
 import { listSubtasksTool, listSubtasksDefinition, createSubtaskTool, createSubtaskDefinition } from './tools/subtasks.js';
@@ -250,7 +250,7 @@ export async function createServer() {
         if (!args?.taskId) {
           throw new Error('taskId is required for task repositioning');
         }
-        return await taskRepositionTool(apiClient, args as z.infer<typeof taskRepositionSchema>);
+        return await taskRepositionTool(apiClient, args);
 
       case 'delete_task':
         return await deleteTaskTool(apiClient, args);

--- a/src/tools/__tests__/task-reposition.test.ts
+++ b/src/tools/__tests__/task-reposition.test.ts
@@ -1,0 +1,203 @@
+/**
+ * @fileoverview Tests reposition_task.
+ *
+ * The old implementation reported success in three situations where it had done nothing
+ * useful: when the API call failed, when it could not find an anchor task, and when it
+ * positioned against unrelated tasks from other lists. Each has a test here.
+ *
+ * @module tools/__tests__/task-reposition.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { ProductiveAPIClient, ProductiveApiError } from '../../api/client.js';
+import { taskRepositionTool } from '../task-reposition.js';
+
+function mockClient(overrides: Record<string, unknown>): ProductiveAPIClient {
+  return overrides as unknown as ProductiveAPIClient;
+}
+
+/** A task that lives in list 2753083. */
+const taskInList = {
+  data: { id: '19300600', relationships: { task_list: { data: { id: '2753083' } } } },
+};
+
+/** What the API returns when a relationship was not requested via include. */
+const taskWithoutInclude = {
+  data: { id: '19300600', relationships: { task_list: { meta: { included: false } } } },
+};
+
+function workingClient() {
+  return {
+    getTask: vi.fn().mockResolvedValue(taskInList),
+    listTasks: vi.fn().mockResolvedValue({ data: [{ id: '111' }, { id: '222' }] }),
+    repositionTask: vi.fn().mockResolvedValue({ success: true }),
+  };
+}
+
+async function errorOf(fn: () => Promise<unknown>) {
+  try {
+    await fn();
+  } catch (err) {
+    return err as { code: number; message: string };
+  }
+  throw new Error('expected a throw, got none');
+}
+
+describe('move_to_top and move_to_bottom', () => {
+  it('resolves the task list with an include, or the ID silently reads as undefined', async () => {
+    const c = workingClient();
+
+    await taskRepositionTool(mockClient(c), { task_id: '19300600', move_to_top: true });
+
+    expect(c.getTask).toHaveBeenCalledWith('19300600', 'task_list');
+  });
+
+  it('asks the API for the top task of that list only, sorted, rather than scanning a page', async () => {
+    const c = workingClient();
+
+    await taskRepositionTool(mockClient(c), { task_id: '19300600', move_to_top: true });
+
+    expect(c.listTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ task_list_id: '2753083', sort: 'placement' })
+    );
+    expect(c.repositionTask).toHaveBeenCalledWith('19300600', { move_before_id: '111' });
+  });
+
+  it('sorts descending for move_to_bottom and positions after', async () => {
+    const c = workingClient();
+
+    await taskRepositionTool(mockClient(c), { task_id: '19300600', move_to_bottom: true });
+
+    expect(c.listTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ task_list_id: '2753083', sort: '-placement' })
+    );
+    expect(c.repositionTask).toHaveBeenCalledWith('19300600', { move_after_id: '111' });
+  });
+
+  it('never anchors a task against itself', async () => {
+    const c = {
+      ...workingClient(),
+      listTasks: vi.fn().mockResolvedValue({ data: [{ id: '19300600' }, { id: '222' }] }),
+    };
+
+    await taskRepositionTool(mockClient(c), { task_id: '19300600', move_to_top: true });
+
+    expect(c.repositionTask).toHaveBeenCalledWith('19300600', { move_before_id: '222' });
+  });
+
+  it('fails instead of claiming success when the task is in no list', async () => {
+    const c = { ...workingClient(), getTask: vi.fn().mockResolvedValue(taskWithoutInclude) };
+
+    const err = await errorOf(() =>
+      taskRepositionTool(mockClient(c), { task_id: '19300600', move_to_top: true })
+    );
+
+    expect(err.code).toBe(ErrorCode.InvalidParams);
+    expect(err.message).toContain('not in a task list');
+    expect(c.repositionTask).not.toHaveBeenCalled();
+  });
+
+  it('fails instead of sending empty attributes when the list holds only this task', async () => {
+    const c = {
+      ...workingClient(),
+      listTasks: vi.fn().mockResolvedValue({ data: [{ id: '19300600' }] }),
+    };
+
+    const err = await errorOf(() =>
+      taskRepositionTool(mockClient(c), { task_id: '19300600', move_to_bottom: true })
+    );
+
+    expect(err.code).toBe(ErrorCode.InvalidParams);
+    expect(err.message).toContain('only task');
+    expect(c.repositionTask).not.toHaveBeenCalled();
+  });
+});
+
+describe('explicit positioning', () => {
+  it('passes move_before_id straight through without a lookup', async () => {
+    const c = workingClient();
+
+    await taskRepositionTool(mockClient(c), { task_id: '1', move_before_id: '2' });
+
+    expect(c.repositionTask).toHaveBeenCalledWith('1', { move_before_id: '2' });
+    expect(c.getTask).not.toHaveBeenCalled();
+  });
+
+  it('passes move_after_id straight through', async () => {
+    const c = workingClient();
+
+    await taskRepositionTool(mockClient(c), { task_id: '1', move_after_id: '2' });
+
+    expect(c.repositionTask).toHaveBeenCalledWith('1', { move_after_id: '2' });
+  });
+});
+
+describe('argument handling', () => {
+  it('accepts the deprecated camelCase names so existing callers keep working', async () => {
+    const c = workingClient();
+
+    await taskRepositionTool(mockClient(c), { taskId: '19300600', moveToTop: true });
+
+    expect(c.repositionTask).toHaveBeenCalledWith('19300600', { move_before_id: '111' });
+  });
+
+  it('rejects a call with no positioning instruction, which used to be a silent no-op', async () => {
+    const c = workingClient();
+
+    const err = await errorOf(() => taskRepositionTool(mockClient(c), { task_id: '1' }));
+
+    expect(err.code).toBe(ErrorCode.InvalidParams);
+    expect(c.repositionTask).not.toHaveBeenCalled();
+  });
+
+  it('rejects contradictory instructions rather than picking one', async () => {
+    const c = workingClient();
+
+    const err = await errorOf(() =>
+      taskRepositionTool(mockClient(c), { task_id: '1', move_to_top: true, move_after_id: '2' })
+    );
+
+    expect(err.code).toBe(ErrorCode.InvalidParams);
+    expect(c.repositionTask).not.toHaveBeenCalled();
+  });
+
+  it('requires a task_id', async () => {
+    const err = await errorOf(() => taskRepositionTool(mockClient({}), { move_to_top: true }));
+
+    expect(err.code).toBe(ErrorCode.InvalidParams);
+  });
+});
+
+describe('failures', () => {
+  it('throws instead of returning the error as ordinary text', async () => {
+    const c = {
+      ...workingClient(),
+      repositionTask: vi.fn().mockRejectedValue(
+        new ProductiveApiError('Record Not Found (404): no such task', 404, [
+          { status: '404', title: 'Record Not Found' },
+        ])
+      ),
+    };
+
+    const err = await errorOf(() =>
+      taskRepositionTool(mockClient(c), { task_id: '1', move_before_id: '2' })
+    );
+
+    expect(err.code).toBe(ErrorCode.InvalidParams);
+    expect(err.message).toContain('Record Not Found');
+  });
+
+  it('reports a server fault as InternalError', async () => {
+    const c = {
+      ...workingClient(),
+      repositionTask: vi.fn().mockRejectedValue(new ProductiveApiError('boom', 500, [])),
+    };
+
+    const err = await errorOf(() =>
+      taskRepositionTool(mockClient(c), { task_id: '1', move_after_id: '2' })
+    );
+
+    expect(err.code).toBe(ErrorCode.InternalError);
+  });
+});

--- a/src/tools/__tests__/task-tools-client.test.ts
+++ b/src/tools/__tests__/task-tools-client.test.ts
@@ -250,11 +250,9 @@ describe('tool layer', () => {
   });
 
   it('never maps errors inline, so a caller fault is never reported as a server fault', () => {
-    // task-reposition.ts returns its errors as plain text instead of throwing, a separate
-    // known bug. It is excluded here so this guard stays about error *codes*.
     const toolsDir = fileURLToPath(new URL('..', import.meta.url));
     const offenders = readdirSync(toolsDir)
-      .filter(f => f.endsWith('.ts') && f !== 'task-reposition.ts')
+      .filter(f => f.endsWith('.ts'))
       .filter(f => readFileSync(join(toolsDir, f), 'utf8').includes('ErrorCode.InternalError'));
 
     expect(offenders).toEqual([]);

--- a/src/tools/task-reposition.ts
+++ b/src/tools/task-reposition.ts
@@ -1,207 +1,192 @@
+/**
+ * @fileoverview reposition_task: move a task within its task list.
+ *
+ * The previous implementation could not work. It called getTask without an `include`, so the
+ * task_list relationship came back as `{"meta": {"included": false}}` and the task list ID was
+ * always undefined. That made the "we know the list" branch dead code, and every call fell
+ * through to fetching 100 arbitrary tasks from across the whole org (2934 of them at the time
+ * of writing), sorting that page by placement, and positioning against whichever unrelated
+ * task happened to come first. When it found nothing it sent empty attributes and reported
+ * success anyway, and it returned API failures as plain text with no isError, so a failed
+ * reposition read as a successful one.
+ *
+ * This version resolves the task's real list, asks the API for the extreme task in that list
+ * directly (`sort=placement` with a page size of one), and refuses to claim success when it
+ * cannot do what was asked.
+ *
+ * @module tools/task-reposition
+ */
+
 import { z } from 'zod';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import type { ProductiveAPIClient } from '../api/client.js';
 import type { TaskReposition } from '../api/types.js';
+import { toMcpError } from '../utils/errors.js';
 
-export const taskRepositionSchema = z.object({
-  taskId: z.string().describe('The ID of the task to reposition'),
-  move_before_id: z.string().optional().describe('Position the task before this task ID'),
-  move_after_id: z.string().optional().describe('Position the task after this task ID'),
-  moveToTop: z.boolean().optional().describe('Move the task to the top of its list'),
-  moveToBottom: z.boolean().optional().describe('Move the task to the bottom of its list'),
-});
+/**
+ * Accepts snake_case, matching every other tool, while still honouring the original
+ * camelCase names so existing callers do not break.
+ */
+export const taskRepositionSchema = z
+  .object({
+    task_id: z.string().optional().describe('The ID of the task to reposition'),
+    taskId: z.string().optional().describe('Deprecated alias for task_id'),
+    move_before_id: z.string().optional().describe('Position the task before this task ID'),
+    move_after_id: z.string().optional().describe('Position the task after this task ID'),
+    move_to_top: z.boolean().optional().describe('Move the task to the top of its list'),
+    moveToTop: z.boolean().optional().describe('Deprecated alias for move_to_top'),
+    move_to_bottom: z.boolean().optional().describe('Move the task to the bottom of its list'),
+    moveToBottom: z.boolean().optional().describe('Deprecated alias for move_to_bottom'),
+  })
+  .transform(v => ({
+    task_id: v.task_id ?? v.taskId,
+    move_before_id: v.move_before_id,
+    move_after_id: v.move_after_id,
+    move_to_top: v.move_to_top ?? v.moveToTop,
+    move_to_bottom: v.move_to_bottom ?? v.moveToBottom,
+  }))
+  .refine(v => Boolean(v.task_id), { message: 'task_id is required' })
+  .refine(
+    v =>
+      [v.move_before_id, v.move_after_id, v.move_to_top || undefined, v.move_to_bottom || undefined]
+        .filter(Boolean).length === 1,
+    { message: 'Provide exactly one of move_before_id, move_after_id, move_to_top or move_to_bottom' }
+  );
 
-export const repositionTask = async (
-  apiClient: ProductiveAPIClient, 
-  data: z.infer<typeof taskRepositionSchema>
-) => {
-  const { taskId, move_before_id, move_after_id, moveToTop, moveToBottom } = data;
+type RepositionParams = z.infer<typeof taskRepositionSchema>;
 
-  // Get the current task to determine its task list
-  const currentTask = await apiClient.getTask(taskId);
-  
-  // Check if the task list ID is available in the response
-  const taskListId = currentTask.data.relationships?.task_list?.data?.id;
-  
-  // If we can't find the task list ID, we'll try a different approach
-  if (!taskListId) {
-    console.warn('Task list ID not found for task', taskId);
-    
-    // Get all tasks and try to find suitable ones to position against
-    const allTasks = await apiClient.listTasks({
-      limit: 100
-    });
-    
-    // Filter out the current task from the list
-    const otherTasks = allTasks.data.filter(task => task.id !== taskId);
-    
-    // Move to top of list (find task with lowest placement and move before it)
-    if (moveToTop && otherTasks.length > 0) {
-      const sortedTasks = [...otherTasks].sort((a, b) => {
-        const placementA = a.attributes.placement || 0;
-        const placementB = b.attributes.placement || 0;
-        return placementA - placementB;
-      });
-      
-      if (sortedTasks.length > 0) {
-        return await apiClient.repositionTask(taskId, {
-          move_before_id: sortedTasks[0].id
-        });
-      }
-    }
-    
-    // Move to bottom of list (find task with highest placement and move after it)
-    if (moveToBottom && otherTasks.length > 0) {
-      const sortedTasks = [...otherTasks].sort((a, b) => {
-        const placementA = a.attributes.placement || 0;
-        const placementB = b.attributes.placement || 0;
-        return placementB - placementA; // Descending order
-      });
-      
-      if (sortedTasks.length > 0) {
-        return await apiClient.repositionTask(taskId, {
-          move_after_id: sortedTasks[0].id
-        });
-      }
-    }
-  } else {
-    // We have a task list ID, so we can filter tasks by that list
-    const tasksInList = await apiClient.listTasks({
-      limit: 100
-    });
-    
-    // Filter tasks in the same list
-    const tasksInSameList = tasksInList.data.filter(task => 
-      task.relationships?.task_list?.data?.id === taskListId && 
-      task.id !== taskId // Exclude the current task
-    );
-    
-    // Move to top of list
-    if (moveToTop && tasksInSameList.length > 0) {
-      const sortedTasks = [...tasksInSameList].sort((a, b) => {
-        const placementA = a.attributes.placement || 0;
-        const placementB = b.attributes.placement || 0;
-        return placementA - placementB;
-      });
-      
-      if (sortedTasks.length > 0) {
-        return await apiClient.repositionTask(taskId, {
-          move_before_id: sortedTasks[0].id
-        });
-      }
-    }
-    
-    // Move to bottom of list
-    if (moveToBottom && tasksInSameList.length > 0) {
-      const sortedTasks = [...tasksInSameList].sort((a, b) => {
-        const placementA = a.attributes.placement || 0;
-        const placementB = b.attributes.placement || 0;
-        return placementB - placementA; // Descending order
-      });
-      
-      if (sortedTasks.length > 0) {
-        return await apiClient.repositionTask(taskId, {
-          move_after_id: sortedTasks[0].id
-        });
-      }
-    }
-  }
-  
-  // Handle explicit positioning parameters if provided
-  if (move_before_id || move_after_id) {
+/**
+ * Find the task at one end of a list.
+ *
+ * Asks the API to sort by placement and returns a single row, so this is exact rather than
+ * "lowest placement in an arbitrary page".
+ *
+ * @param client - API client.
+ * @param taskListId - The list to look in.
+ * @param end - Which end to find.
+ * @param excludeTaskId - The task being moved, which cannot anchor against itself.
+ * @returns The anchor task ID, or undefined if the list has no other task.
+ */
+async function findEdgeTask(
+  client: ProductiveAPIClient,
+  taskListId: string,
+  end: 'top' | 'bottom',
+  excludeTaskId: string
+): Promise<string | undefined> {
+  const response = await client.listTasks({
+    task_list_id: taskListId,
+    sort: end === 'top' ? 'placement' : '-placement',
+    limit: 2, // Two, so the task being moved can be skipped without a second request.
+  });
+
+  return response.data.find(t => t.id !== excludeTaskId)?.id;
+}
+
+/**
+ * Reposition a task, resolving move_to_top and move_to_bottom against its real list.
+ *
+ * @param client - API client.
+ * @param params - Validated parameters.
+ * @returns A human-readable description of what was done.
+ * @throws McpError if the move cannot be performed, rather than reporting a false success.
+ */
+export async function repositionTask(
+  client: ProductiveAPIClient,
+  params: RepositionParams
+): Promise<string> {
+  const taskId = params.task_id as string;
+
+  if (params.move_before_id || params.move_after_id) {
     const attributes: TaskReposition = {};
-    if (move_before_id) attributes.move_before_id = move_before_id;
-    if (move_after_id) attributes.move_after_id = move_after_id;
-    return await apiClient.repositionTask(taskId, attributes);
+    if (params.move_before_id) attributes.move_before_id = params.move_before_id;
+    if (params.move_after_id) attributes.move_after_id = params.move_after_id;
+    await client.repositionTask(taskId, attributes);
+    return params.move_before_id
+      ? `Task ${taskId} moved before task ${params.move_before_id}.`
+      : `Task ${taskId} moved after task ${params.move_after_id}.`;
   }
-  
-  // As a last resort, try default API behavior with empty attributes
-  console.warn('Using default repositioning with empty attributes');
-  return await apiClient.repositionTask(taskId, {});
-};
+
+  const end = params.move_to_top ? 'top' : 'bottom';
+
+  // The include is load-bearing. Without it the relationship is {"meta":{"included":false}}
+  // and the list ID silently reads as undefined, which is what broke this tool before.
+  const { data: task } = await client.getTask(taskId, 'task_list');
+  const taskListId = task.relationships?.task_list?.data?.id;
+
+  if (!taskListId) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Task ${taskId} is not in a task list, so it cannot be moved to the ${end} of one. ` +
+        `Use move_before_id or move_after_id to position it against a specific task.`
+    );
+  }
+
+  const anchorId = await findEdgeTask(client, taskListId, end, taskId);
+
+  if (!anchorId) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Task ${taskId} is the only task in task list ${taskListId}, so there is nothing to ` +
+        `move it ${end === 'top' ? 'above' : 'below'}. It is already at the ${end}.`
+    );
+  }
+
+  await client.repositionTask(
+    taskId,
+    end === 'top' ? { move_before_id: anchorId } : { move_after_id: anchorId }
+  );
+
+  return `Task ${taskId} moved to the ${end} of task list ${taskListId} (${
+    end === 'top' ? 'before' : 'after'
+  } task ${anchorId}).`;
+}
+
+export async function taskRepositionTool(
+  client: ProductiveAPIClient,
+  args: unknown
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const params = taskRepositionSchema.parse(args);
+    const summary = await repositionTask(client, params);
+
+    return { content: [{ type: 'text', text: summary }] };
+  } catch (error) {
+    // Previously this returned the error as ordinary text, so a failed reposition was
+    // indistinguishable from a successful one.
+    throw toMcpError(error);
+  }
+}
 
 export const taskRepositionDefinition = {
   name: 'reposition_task',
-  description: 'Reposition a task in a task list',
+  description:
+    'Move a task within its task list. Provide exactly one of move_before_id, move_after_id, ' +
+    'move_to_top or move_to_bottom. move_to_top and move_to_bottom resolve against the task\'s ' +
+    'own task list, and fail rather than reporting success if the task is not in a list.',
   inputSchema: {
     type: 'object',
     properties: {
-      taskId: {
+      task_id: {
         type: 'string',
-        description: 'The ID of the task to reposition'
+        description: 'The ID of the task to reposition (required)',
       },
       move_before_id: {
         type: 'string',
-        description: 'Position the task before this task ID'
+        description: 'Position the task before this task ID',
       },
       move_after_id: {
         type: 'string',
-        description: 'Position the task after this task ID'
+        description: 'Position the task after this task ID',
       },
-      moveToTop: {
+      move_to_top: {
         type: 'boolean',
-        description: 'Move the task to the top of its list'
+        description: 'Move the task to the top of its own task list',
       },
-      moveToBottom: {
+      move_to_bottom: {
         type: 'boolean',
-        description: 'Move the task to the bottom of its list'
-      }
+        description: 'Move the task to the bottom of its own task list',
+      },
     },
-    required: ['taskId']
-  }
-};
-
-export const taskRepositionTool = async (apiClient: ProductiveAPIClient, args: z.infer<typeof taskRepositionSchema>) => {
-  try {
-    const result = await repositionTask(apiClient, args);
-    
-    // Format the response to match the MCP tool expected format
-    // Handle the new response format which is a success object
-    if (result.success) {
-      return {
-        content: [{
-          type: 'text',
-          text: `Task ${args.taskId} repositioned successfully.
-The task has been moved ${args.moveToTop ? 'to the top of the list' : 
-                           args.moveToBottom ? 'to the bottom of the list' : 
-                           args.move_before_id ? `before task ${args.move_before_id}` : 
-                           args.move_after_id ? `after task ${args.move_after_id}` : 
-                           'to a new position'}.`,
-        }],
-      };
-    } else if (result.data) {
-      // Fallback for old response format if somehow returned
-      return {
-        content: [{
-          type: 'text',
-          text: `Task ${result.data.id} repositioned successfully.
-Title: ${result.data.attributes?.title || 'Unknown'}
-Position updated according to the requested parameters.`,
-        }],
-      };
-    } else {
-      // Generic success if neither format is matched
-      return {
-        content: [{
-          type: 'text',
-          text: `Task repositioning operation completed successfully.`,
-        }],
-      };
-    }
-  } catch (error) {
-    // Handle errors more gracefully
-    console.error('Error in taskRepositionTool:', error);
-    return {
-      content: [{
-        type: 'text',
-        text: `Error repositioning task: ${error instanceof Error ? error.message : 'Unknown error occurred'}`,
-      }],
-    };
-  }
-};
-
-export default {
-  name: 'reposition_task',
-  description: 'Reposition a task in a task list',
-  inputSchema: taskRepositionDefinition.inputSchema,
-  execute: repositionTask,
+    required: ['task_id'],
+  },
 };


### PR DESCRIPTION
## This was not a style problem

Outstanding item 6 was recorded as cosmetic: camelCase params, errors returned as text, a dead
`export default`. Reading the code, **`move_to_top` and `move_to_bottom` never worked.**

The tool called `getTask(taskId)` with no `include`, so the `task_list` relationship came back
as `{"meta": {"included": false}}` and the list ID was **always** undefined. That made the
entire "we know the task list" branch dead code. Every call fell through to fetching 100
arbitrary tasks from across the whole org, sorting that page by placement, and positioning the
task against whichever unrelated task happened to come first. When it found nothing, it sent
empty attributes and reported success anyway.

## Verified against the live API before changing anything

```
getTask WITHOUT include -> task_list: {"meta":{"included":false}}
getTask WITH include    -> task_list: {"data":{"type":"task_lists","id":"2753083"}}

unfiltered page of 100 tasks -> contained 0 tasks from the target list
filter[task_list_id]=2753083 -> 196 of 2934 total, all genuinely in that list
sort=placement / sort=-placement -> different tasks, so sorting is supported
```

So the anchor task can be fetched exactly, in one request, rather than approximated from a
page scan that was looking at the wrong tasks anyway.

## What it does now

Resolves the task's real list, then asks the API for the edge task of that list with `sort`
and a page size of two. Two rather than one, so the task being moved can be skipped without a
second request.

It refuses to claim success when it cannot do what was asked:

| situation | before | now |
|---|---|---|
| task not in a task list | "repositioned successfully" | `InvalidParams`, suggests `move_before_id` |
| task alone in its list | "repositioned successfully" | `InvalidParams`, says it is already at that end |
| no positioning argument | empty reposition, reported success | `InvalidParams` |
| contradictory arguments | silently picked one | `InvalidParams` |
| API call failed | error text with no `isError` | throws via `toMcpError` |

That last row is why this mattered: a failed reposition was indistinguishable from a
successful one. The no-inline-mapping guard from #39 no longer needs to exclude this file.

## Also

- Params are snake_case like every other tool. `taskId`, `moveToTop` and `moveToBottom` are
  still accepted as deprecated aliases, so nothing that already calls this breaks.
- Removes the dead `export default` that duplicated the tool name with a mismatched `execute`.
- Adds `task_list_id` and `sort` to `client.listTasks`.

## Verification, and its limit

Live-verified that all three failure paths now throw `-32602` where they previously returned
success text:

```
nonexistent task, move_to_top  -> threw -32602 | Record Not Found (404)
no positioning instruction     -> threw -32602 | Provide exactly one of move_before_id...
contradictory instructions     -> threw -32602 | Provide exactly one of move_before_id...
```

**The happy path is covered by unit tests only.** Repositioning a real task writes to your
production board, so I did not do it. The tests pin the anchor selection, both sort
directions, and that a task is never anchored against itself, but if you want a live
round-trip before trusting it, that is a reasonable ask and I would rather you decide.

220 tests passing, type-check clean, smoke test passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)